### PR TITLE
Separate generation and clustering flows

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ from indexation.helpers import (
     pca_2d,
     load_transcripts,
     get_nested_value,
+    suggest_cluster_names,
 )
 
 app = Flask(__name__)
@@ -46,10 +47,14 @@ def cleanup_previews(max_age=3600):
             PREVIEW_INDEX.pop(token, None)
 
 
+# -----------------------------------------------------
+# Landing and common API endpoints
+# -----------------------------------------------------
+
+
 @app.get("/")
-def home():
-    fields = discover_fields()
-    return render_template("index.html", api_base=API_BASE, fields=fields, id_guess=ID_GUESS)
+def landing():
+    return render_template("home.html")
 
 
 @app.get("/api/fields")
@@ -77,136 +82,186 @@ def api_sample():
     return jsonify(sample=out)
 
 
-@app.post("/preview-excel")
-def preview_excel():
-    cleanup_previews()
-    f = request.files.get("excel")
-    if not f or f.filename == "":
-        return jsonify(error="No file uploaded"), 400
-    token = uuid.uuid4().hex
-    tmp = DATA_DIR / f"preview_{token}{Path(f.filename).suffix}"
-    f.save(tmp)
-    try:
-        if tmp.suffix.lower() in [".xlsx", ".xls"]:
-            df = pd.read_excel(tmp)
-        else:
-            df = pd.read_csv(tmp)
-    except Exception as e:
-        return jsonify(error=f"Cannot read file: {e}"), 400
-
-    preview = df.head(50)
-    cols = list(df.columns)
-    PREVIEW_INDEX[token] = {"path": tmp, "ts": time.time()}
-    return jsonify(
-        columns=cols,
-        preview=preview.to_dict(orient="records"),
-        token=token,
-    )
+# -----------------------------------------------------
+# Generation
+# -----------------------------------------------------
 
 
-@app.post("/ingest")
-def ingest():
-    cleanup_previews()
-    mode = request.form.get("mode", "api")
-    primary_key = request.form.get("primary_key", "").strip()
-    embed_fields = ensure_list(request.form.getlist("embed_fields"))
-    k_choice = request.form.get("k_choice", "auto").strip()
-    algo_choice = request.form.get("algo_choice", "kmeans").strip()
-
-    if not primary_key:
-        flash("Please choose a primary key from the API fields.")
-        return redirect(url_for("home"))
-    if not embed_fields:
-        flash("Select at least one field to embed.")
-        return redirect(url_for("home"))
-
+def build_dataset(primary_key, embed_fields, mode, excel_token, excel_id_col, transcripts_files):
+    """Fetch programs, filter and attach transcripts. Returns (df, pk_col)."""
     try:
         programs = fetch_all_programs()
     except Exception as e:
-        flash(f"API error: {e}")
-        return redirect(url_for("home"))
+        raise RuntimeError(f"API error: {e}")
 
     if not programs:
-        flash("No data returned by the API.")
-        return redirect(url_for("home"))
+        raise RuntimeError("No data returned by the API")
 
     wanted_ids = None
     if mode == "excel":
-        token = request.form.get("excel_token", "")
-        excel_id_col = request.form.get("excel_id_col", "")
-        if not token or not excel_id_col:
-            flash("Excel filter selected but missing file preview token or ID column.")
-            return redirect(url_for("home"))
-
-        info = PREVIEW_INDEX.pop(token, None)
+        info = PREVIEW_INDEX.pop(excel_token or "", None)
         if not info or not info["path"].exists():
-            flash("Uploaded Excel token expired; please re-upload.")
-            return redirect(url_for("home"))
+            raise RuntimeError("Uploaded Excel token expired; please re-upload")
 
         tmp = info["path"]
         if tmp.suffix.lower() in [".xlsx", ".xls"]:
             df_ids = pd.read_excel(tmp)
         else:
             df_ids = pd.read_csv(tmp)
-
         try:
             tmp.unlink(missing_ok=True)
         except Exception:
             pass
-
         if excel_id_col not in df_ids.columns:
-            flash("Chosen ID column not found in uploaded file.")
-            return redirect(url_for("home"))
-
+            raise RuntimeError("Chosen ID column not found in uploaded file")
         wanted_ids = set(df_ids[excel_id_col].astype(str).str.strip().tolist())
 
     df = pd.DataFrame(programs)
-
     if "." in primary_key or primary_key not in df.columns:
         df["_pk"] = df.apply(lambda r: get_nested_value(r.to_dict(), primary_key), axis=1)
         pk_col = "_pk"
         if df[pk_col].isna().all():
-            flash(f"Primary key '{primary_key}' not found in API data.")
-            return redirect(url_for("home"))
+            raise RuntimeError(f"Primary key '{primary_key}' not found in API data")
     else:
         pk_col = primary_key
 
     if wanted_ids is not None:
         df = df[df[pk_col].astype(str).str.strip().isin(wanted_ids)].copy()
         if df.empty:
-            flash("None of the provided IDs matched the API data.")
-            return redirect(url_for("home"))
+            raise RuntimeError("None of the provided IDs matched the API data")
 
-    transcripts_map = load_transcripts(request.files.getlist("transcripts"))
+    transcripts_map = load_transcripts(transcripts_files)
     if transcripts_map:
         df["transcript_text"] = df[pk_col].astype(str).map(transcripts_map).fillna("")
         if "transcript_text" not in embed_fields:
             embed_fields.append("transcript_text")
 
-    emb_file = request.files.get("embedding_file")
-    if emb_file and emb_file.filename:
-        tmp_emb = DATA_DIR / f"upload_emb_{uuid.uuid4().hex}.npy"
-        emb_file.save(tmp_emb)
-        X = np.load(tmp_emb)
-        if X.shape[0] != len(df):
-            flash("Embedding file size mismatch with API data.")
-            return redirect(url_for("home"))
-    else:
-        texts = []
-        for _, row in df.iterrows():
-            texts.append(build_text_from_fields(row.to_dict(), embed_fields))
-        df["_text_for_embedding"] = texts
-        df = df[df["_text_for_embedding"].astype(str).str.strip() != ""]
-        if df.empty:
-            flash("Nothing to embed after field selection. Check your embed fields.")
-            return redirect(url_for("home"))
+    return df, pk_col
 
-        try:
-            embs = batch_embed(df["_text_for_embedding"].tolist())
-        except Exception as e:
-            flash(f"Embedding error: {e}")
-            return redirect(url_for("home"))
-        X = np.vstack(embs)
+
+@app.get("/generate")
+def generate_page():
+    fields = discover_fields()
+    return render_template("generate.html", api_base=API_BASE, fields=fields, id_guess=ID_GUESS)
+
+
+@app.post("/generate/preview")
+def generate_preview():
+    mode = request.form.get("mode", "api")
+    primary_key = request.form.get("primary_key", "").strip()
+    embed_fields = ensure_list(request.form.getlist("embed_fields"))
+    excel_token = request.form.get("excel_token", "")
+    excel_id_col = request.form.get("excel_id_col", "")
+
+    if not primary_key or not embed_fields:
+        return jsonify(error="Missing primary key or fields"), 400
+
+    try:
+        df, pk_col = build_dataset(primary_key, embed_fields.copy(), mode, excel_token, excel_id_col, request.files.getlist("transcripts"))
+    except RuntimeError as e:
+        return jsonify(error=str(e)), 400
+
+    title_col = next((c for c in TITLE_COL_CANDIDATES if c in df.columns), None)
+    prev = df[[pk_col] + ([title_col] if title_col else [])].copy()
+    prev["has_transcript"] = df.get("transcript_text", "").astype(str).str.strip() != ""
+    return jsonify(rows=prev.head(50).to_dict(orient="records"))
+
+
+@app.post("/generate")
+def run_generate():
+    mode = request.form.get("mode", "api")
+    primary_key = request.form.get("primary_key", "").strip()
+    embed_fields = ensure_list(request.form.getlist("embed_fields"))
+    excel_token = request.form.get("excel_token", "")
+    excel_id_col = request.form.get("excel_id_col", "")
+
+    if not primary_key:
+        flash("Please choose a primary key from the API fields.")
+        return redirect(url_for("generate_page"))
+    if not embed_fields:
+        flash("Select at least one field to embed.")
+        return redirect(url_for("generate_page"))
+
+    try:
+        df, pk_col = build_dataset(primary_key, embed_fields, mode, excel_token, excel_id_col, request.files.getlist("transcripts"))
+    except RuntimeError as e:
+        flash(str(e))
+        return redirect(url_for("generate_page"))
+
+    texts = [build_text_from_fields(row.to_dict(), embed_fields) for _, row in df.iterrows()]
+    df["_text_for_embedding"] = texts
+    df = df[df["_text_for_embedding"].astype(str).str.strip() != ""]
+    if df.empty:
+        flash("Nothing to embed after field selection. Check your embed fields.")
+        return redirect(url_for("generate_page"))
+
+    try:
+        embs = batch_embed(df["_text_for_embedding"].tolist())
+    except Exception as e:
+        flash(f"Embedding error: {e}")
+        return redirect(url_for("generate_page"))
+    X = np.vstack(embs)
+
+    uid = str(uuid.uuid4())[:8]
+    raw_name = f"raw_{uid}.parquet"
+    emb_name = f"emb_{uid}.npy"
+    df.to_parquet(DATA_DIR / raw_name, index=False)
+    np.save(DATA_DIR / emb_name, X)
+
+    return render_template(
+        "generate_done.html",
+        uid=uid,
+        parquet=url_for("download_result", name=raw_name),
+        embeddings=url_for("download_result", name=emb_name),
+    )
+
+
+# -----------------------------------------------------
+# Clustering
+# -----------------------------------------------------
+
+
+@app.get("/cluster")
+def cluster_page():
+    existing = []
+    for p in DATA_DIR.glob("raw_*.parquet"):
+        uid = p.stem.split("_", 1)[1]
+        emb = DATA_DIR / f"emb_{uid}.npy"
+        if emb.exists():
+            existing.append({"uid": uid, "parquet": p.name, "emb": emb.name})
+    preselect = request.args.get("uid", "")
+    return render_template("cluster.html", existing=existing, preselect=preselect)
+
+
+@app.post("/cluster")
+def run_cluster():
+    existing_uid = request.form.get("existing_uid", "").strip()
+    k_choice = request.form.get("k_choice", "auto").strip()
+    algo_choice = request.form.get("algo_choice", "kmeans").strip()
+
+    if existing_uid:
+        df_path = DATA_DIR / f"raw_{existing_uid}.parquet"
+        emb_path = DATA_DIR / f"emb_{existing_uid}.npy"
+        if not df_path.exists() or not emb_path.exists():
+            flash("Selected dataset not found.")
+            return redirect(url_for("cluster_page"))
+    else:
+        df_file = request.files.get("dataset_file")
+        emb_file = request.files.get("embedding_file")
+        if not df_file or not emb_file:
+            flash("Please provide dataset and embedding files.")
+            return redirect(url_for("cluster_page"))
+        uid = uuid.uuid4().hex[:8]
+        df_path = DATA_DIR / f"upload_{uid}.parquet"
+        emb_path = DATA_DIR / f"upload_{uid}.npy"
+        df_file.save(df_path)
+        emb_file.save(emb_path)
+
+    df = pd.read_parquet(df_path)
+    X = np.load(emb_path)
+    if X.shape[0] != len(df):
+        flash("Embedding file size mismatch with dataset.")
+        return redirect(url_for("cluster_page"))
 
     if algo_choice == "dbscan":
         db = DBSCAN()
@@ -230,28 +285,24 @@ def ingest():
     df["_x"] = coords[:, 0]
     df["_y"] = coords[:, 1]
 
-    uid = str(uuid.uuid4())[:8]
+    uid = existing_uid or uuid.uuid4().hex[:8]
     out_name = f"result_{uid}.parquet"
-    out_path = DATA_DIR / out_name
-    df.to_parquet(out_path, index=False)
-    emb_name = f"emb_{uid}.npy"
-    np.save(DATA_DIR / emb_name, X)
+    df.to_parquet(DATA_DIR / out_name, index=False)
 
     title_col = next((c for c in TITLE_COL_CANDIDATES if c in df.columns), None)
+    cluster_names = suggest_cluster_names(df, title_col) if title_col else {}
 
     payload = {
         "meta": {
             "k": int(k),
             "silhouette": float(sil),
             "points": int(len(df)),
-            "primary_key": primary_key,
-            "embed_fields": embed_fields,
-            "mode": mode,
             "algo": algo_choice,
+            "cluster_names": cluster_names,
         },
         "points": [
             {
-                "id": str(row[pk_col]),
+                "id": str(row.get("id", row.index)),
                 "title": str(row[title_col]) if title_col else "",
                 "cluster": int(row["_cluster"]),
                 "x": float(row["_x"]),
@@ -259,14 +310,42 @@ def ingest():
             }
             for _, row in df.iterrows()
         ],
-        "columns": {"id": primary_key, "title": title_col},
+        "columns": {"title": title_col},
         "download": {
             "parquet": url_for("download_result", name=out_name),
-            "embeddings": url_for("download_result", name=emb_name),
+            "embeddings": url_for("download_result", name=emb_path.name),
         },
     }
 
     return render_template("results.html", payload_json=json.dumps(payload))
+
+
+# -----------------------------------------------------
+# Utilities
+# -----------------------------------------------------
+
+
+@app.post("/preview-excel")
+def preview_excel():
+    cleanup_previews()
+    f = request.files.get("excel")
+    if not f or f.filename == "":
+        return jsonify(error="No file uploaded"), 400
+    token = uuid.uuid4().hex
+    tmp = DATA_DIR / f"preview_{token}{Path(f.filename).suffix}"
+    f.save(tmp)
+    try:
+        if tmp.suffix.lower() in [".xlsx", ".xls"]:
+            df = pd.read_excel(tmp)
+        else:
+            df = pd.read_csv(tmp)
+    except Exception as e:
+        return jsonify(error=f"Cannot read file: {e}"), 400
+
+    preview = df.head(50)
+    cols = list(df.columns)
+    PREVIEW_INDEX[token] = {"path": tmp, "ts": time.time()}
+    return jsonify(columns=cols, preview=preview.to_dict(orient="records"), token=token)
 
 
 @app.get("/download/<name>")
@@ -277,3 +356,4 @@ def download_result(name):
     if not candidate.exists() or not candidate.name.endswith(tuple([".parquet", ".npy"])):
         abort(404)
     return send_from_directory(DATA_DIR, candidate.name, as_attachment=True)
+

--- a/templates/cluster.html
+++ b/templates/cluster.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <title>Clustering</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
+</head>
+<body class="bg-dark text-light">
+<div class="container py-4">
+  <h1 class="mb-3">Clustering</h1>
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="alert alert-danger">
+        {% for msg in messages %}<div>{{ msg }}</div>{% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+
+  <form method="post" action="{{ url_for('run_cluster') }}" enctype="multipart/form-data" class="step">
+    <h5 class="mb-2">Données</h5>
+    {% if existing %}
+      <div class="mb-3">
+        <label class="form-label">Jeux générés récemment</label>
+        <select name="existing_uid" id="existingUid" class="form-select form-select-sm">
+          <option value="">-- Choisir --</option>
+          {% for e in existing %}
+            <option value="{{ e.uid }}" {% if e.uid == preselect %}selected{% endif %}>{{ e.parquet }} / {{ e.emb }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    {% endif %}
+    <div class="mb-3">
+      <label class="form-label">Ou charger un jeu de données (.parquet)</label>
+      <input type="file" name="dataset_file" class="form-control form-control-sm" accept=".parquet" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Embeddings (.npy)</label>
+      <input type="file" name="embedding_file" class="form-control form-control-sm" accept=".npy" />
+    </div>
+    <div class="row g-2">
+      <div class="col-md-3">
+        <label class="form-label">Nombre de clusters</label>
+        <select name="k_choice" class="form-select form-select-sm">
+          <option value="auto" selected>Auto</option>
+          <option value="4">4</option>
+          <option value="6">6</option>
+          <option value="8">8</option>
+          <option value="10">10</option>
+        </select>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Algorithme</label>
+        <select name="algo_choice" class="form-select form-select-sm">
+          <option value="kmeans" selected>K-Means</option>
+          <option value="dbscan">DBSCAN</option>
+        </select>
+      </div>
+    </div>
+    <div class="mt-3">
+      <button class="btn btn-primary">Cluster</button>
+    </div>
+  </form>
+</div>
+</body>
+</html>

--- a/templates/generate.html
+++ b/templates/generate.html
@@ -99,59 +99,38 @@
     <div id="embedPreviewContent" class="small"></div>
   </div>
 
-  <h2 class="mt-4">Clustering</h2>
+  <!-- STEP 4: Preview & generation -->
+  <div class="step">
+    <h5 class="mb-2">Étape 4 — Prévisualisation & génération</h5>
+    <form id="generateForm" method="post" action="{{ url_for('run_generate') }}" enctype="multipart/form-data">
+      <input type="hidden" name="mode" id="f_mode" value="api">
+      <input type="hidden" name="primary_key" id="f_primary_key">
+      <div id="embedHidden"></div>
+      <input type="hidden" name="excel_token" id="f_excel_token">
+      <input type="hidden" name="excel_id_col" id="f_excel_id_col">
 
-    <!-- STEP 4: Clustering options -->
-    <div class="step">
-      <h5 class="mb-2">Étape 4 — Options de clustering</h5>
-      <div class="row g-2">
-        <div class="col-md-3">
-          <label class="form-label">Nombre de clusters</label>
-          <select id="kChoice" class="form-select form-select-sm">
-            <option value="auto" selected>Auto (recommandé)</option>
-            <option value="4">4</option>
-            <option value="6">6</option>
-            <option value="8">8</option>
-            <option value="10">10</option>
-          </select>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Algorithme</label>
-          <select id="algoChoice" class="form-select form-select-sm">
-            <option value="kmeans" selected>K-Means</option>
-            <option value="dbscan">DBSCAN</option>
-          </select>
-        </div>
+      <div class="mb-3">
+        <label class="form-label">Transcriptions (.docx)</label>
+        <input type="file" name="transcripts" id="transcripts" class="form-control form-control-sm" multiple accept=".docx" />
+        <div class="form-text text-secondary">Les noms doivent contenir l’identifiant numérique (ex: AUTHOR_123456.docx).</div>
       </div>
-    </div>
 
-    <!-- STEP 5: Optional files + submit -->
-    <div class="step">
-      <h5 class="mb-2">Étape 5 — Fichiers optionnels & lancement</h5>
-      <form id="runForm" method="post" action="{{ url_for('ingest') }}" enctype="multipart/form-data">
-        <input type="hidden" name="mode" id="f_mode" value="api">
-        <input type="hidden" name="primary_key" id="f_primary_key">
-        <input type="hidden" name="k_choice" id="f_k_choice" value="auto">
-        <input type="hidden" name="algo_choice" id="f_algo_choice" value="kmeans">
-        <div id="embedHidden"></div>
-        <input type="hidden" name="excel_token" id="f_excel_token">
-        <input type="hidden" name="excel_id_col" id="f_excel_id_col">
+      <button id="btnDataPreview" type="button" class="btn btn-secondary btn-sm">Prévisualiser les émissions</button>
+      <span id="dataSpinner" class="ms-2 d-none spinner-border spinner-border-sm"></span>
+      <div id="dataPreview" class="table-preview mt-3 d-none">
+        <table class="table table-dark table-striped table-sm">
+          <thead></thead>
+          <tbody></tbody>
+        </table>
+      </div>
 
-        <div class="mb-3">
-          <label class="form-label">Transcriptions (.docx)</label>
-          <input type="file" name="transcripts" id="transcripts" class="form-control form-control-sm" multiple accept=".docx" />
-          <div class="form-text text-secondary">Les noms doivent contenir l’identifiant numérique (ex: AUTHOR_123456.docx).</div>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Embeddings pré-générés (.npy)</label>
-          <input type="file" name="embedding_file" id="embeddingFile" class="form-control form-control-sm" accept=".npy" />
-        </div>
-
-        <button id="btnRun" class="btn btn-primary">Analyser</button>
+      <div class="mt-3">
+        <button id="btnRun" class="btn btn-primary">Générer</button>
         <span id="runSpinner" class="ms-2 d-none spinner-border spinner-border-sm"></span>
-      </form>
-      <div class="muted mt-2">Le traitement peut prendre un peu de temps selon la taille.</div>
-    </div>
+      </div>
+    </form>
+    <div class="muted mt-2">Le traitement peut prendre un peu de temps selon la taille.</div>
+  </div>
 
 </div>
 
@@ -297,16 +276,12 @@ $("#excelPreviewForm").addEventListener("submit", async (e) => {
   }
 });
 
-// Submit run
-  $("#runForm").addEventListener("submit", (e) => {
-    // move UI selections into hidden fields
-    const mode = $("#modeExcel").checked ? "excel" : "api";
-    $("#f_mode").value = mode;
-    $("#f_primary_key").value = $("#primaryKey").value;
-    $("#f_k_choice").value = $("#kChoice").value;
-    $("#f_algo_choice").value = $("#algoChoice").value;
+// Submit generation
+$("#generateForm").addEventListener("submit", (e) => {
+  const mode = $("#modeExcel").checked ? "excel" : "api";
+  $("#f_mode").value = mode;
+  $("#f_primary_key").value = $("#primaryKey").value;
 
-  // embed fields
   const wrap = $("#embedHidden");
   wrap.innerHTML = "";
   Array.from($("#embedFields").selectedOptions).forEach(o => {
@@ -317,14 +292,54 @@ $("#excelPreviewForm").addEventListener("submit", async (e) => {
     wrap.appendChild(inp);
   });
 
-    if (mode === "excel") {
-      if (!excelToken) { e.preventDefault(); alert("Prévisualiser d’abord le fichier Excel."); return; }
-      $("#f_excel_token").value = excelToken;
-      $("#f_excel_id_col").value = $("#excelIdCol").value;
-    }
+  if (mode === "excel") {
+    if (!excelToken) { e.preventDefault(); alert("Prévisualiser d’abord le fichier Excel."); return; }
+    $("#f_excel_token").value = excelToken;
+    $("#f_excel_id_col").value = $("#excelIdCol").value;
+  }
 
   $("#btnRun").classList.add("disabled");
   $("#runSpinner").classList.remove("d-none");
+});
+
+// Data preview
+$("#btnDataPreview").addEventListener("click", async () => {
+  const mode = $("#modeExcel").checked ? "excel" : "api";
+  const fd = new FormData();
+  fd.append("mode", mode);
+  fd.append("primary_key", $("#primaryKey").value);
+  Array.from($("#embedFields").selectedOptions).forEach(o => fd.append("embed_fields", o.value));
+  if (mode === "excel") {
+    if (!excelToken) { alert("Prévisualiser d’abord le fichier Excel."); return; }
+    fd.append("excel_token", excelToken);
+    fd.append("excel_id_col", $("#excelIdCol").value);
+  }
+  Array.from($("#transcripts").files).forEach(f => fd.append("transcripts", f));
+  setLoading("#btnDataPreview", "#dataSpinner", true);
+  try {
+    const res = await fetch("{{ url_for('generate_preview') }}", { method: "POST", body: fd });
+    const js = await res.json();
+    if (js.error) { alert(js.error); return; }
+    const head = $("#dataPreview thead"); head.innerHTML = "";
+    const body = $("#dataPreview tbody"); body.innerHTML = "";
+    if (js.rows && js.rows.length) {
+      const cols = Object.keys(js.rows[0]);
+      const trh = document.createElement("tr");
+      cols.forEach(c => { const th = document.createElement("th"); th.textContent = c; trh.appendChild(th); });
+      head.appendChild(trh);
+      js.rows.forEach(r => {
+        const tr = document.createElement("tr");
+        cols.forEach(c => { const td = document.createElement("td"); td.textContent = r[c]; tr.appendChild(td); });
+        body.appendChild(tr);
+      });
+      $("#dataPreview").classList.remove("d-none");
+    }
+  } catch (e) {
+    console.error(e);
+    alert("Erreur de prévisualisation des émissions.");
+  } finally {
+    setLoading("#btnDataPreview", "#dataSpinner", false);
+  }
 });
 </script>
 

--- a/templates/generate_done.html
+++ b/templates/generate_done.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <title>Embeddings générés</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
+</head>
+<body class="bg-dark text-light">
+  <div class="container py-4">
+    <h1>Embeddings générés</h1>
+    <p>Les fichiers ont été enregistrés. Vous pouvez maintenant lancer le clustering.</p>
+    <ul>
+      <li><a href="{{ parquet }}" class="link-light">Télécharger le jeu de données</a></li>
+      <li><a href="{{ embeddings }}" class="link-light">Télécharger les embeddings</a></li>
+    </ul>
+    <a href="{{ url_for('cluster_page') }}?uid={{ uid }}" class="btn btn-primary">Aller au clustering</a>
+  </div>
+</body>
+</html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <title>Edu Topics</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
+</head>
+<body class="bg-dark text-light">
+  <div class="container py-5 text-center">
+    <h1 class="mb-4">Edu Topics</h1>
+    <p class="lead">Choisissez une action</p>
+    <div class="d-flex justify-content-center gap-3 mt-4">
+      <a href="{{ url_for('generate_page') }}" class="btn btn-primary btn-lg">Générer des embeddings</a>
+      <a href="{{ url_for('cluster_page') }}" class="btn btn-secondary btn-lg">Clustering</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/results.html
+++ b/templates/results.html
@@ -15,6 +15,7 @@
       const meta = payload.meta || {};
       const clusters = [...new Set(points.map(p => p.cluster))].sort((a,b)=>a-b);
 
+      const names = meta.cluster_names || {};
       const traces = clusters.map(c => {
         const pts = points.filter(p => p.cluster === c);
         return {
@@ -22,7 +23,7 @@
           y: pts.map(p => p.y),
           mode: "markers",
           type: "scattergl",
-          name: `Cluster ${c}`,
+          name: names[c] ? `${c} - ${names[c]}` : `Cluster ${c}`,
           text: pts.map(p => (p.title || p.id || "")),
           hovertemplate: "<b>%{text}</b><br>x=%{x:.2f}, y=%{y:.2f}<extra></extra>",
           marker: { size: 9 }
@@ -44,15 +45,6 @@
       );
 
       // Fill summary
-      document.getElementById("summaryMode").textContent = meta.mode === "excel" ? "Filtré par Excel" : "Catalogue API";
-      document.getElementById("summaryPK").textContent = meta.primary_key;
-      const ef = document.getElementById("summaryFields");
-      (meta.embed_fields || []).forEach(f => {
-        const span = document.createElement("span");
-        span.className = "badge text-bg-secondary me-1";
-        span.textContent = f;
-        ef.appendChild(span);
-      });
       document.getElementById("summaryAlgo").textContent = meta.algo || "";
 
       // Build cluster counts
@@ -67,7 +59,8 @@
       const tbody = document.querySelector("#summary tbody");
       rows.forEach(r => {
         const tr = document.createElement("tr");
-        tr.innerHTML = `<td>${r.cluster}</td><td>${r.count}</td>`;
+        const name = names[r.cluster] || "";
+        tr.innerHTML = `<td>${r.cluster}</td><td>${name}</td><td>${r.count}</td>`;
         tbody.appendChild(tr);
       });
 
@@ -84,19 +77,12 @@
       <div class="d-flex gap-2">
         <a id="dl" class="btn btn-primary">Télécharger le Parquet</a>
         <a id="dlEmb" class="btn btn-secondary">Télécharger Embeddings</a>
-        <a href="{{ url_for('home') }}" class="btn btn-outline-light">Nouvelle analyse</a>
+        <a href="{{ url_for('landing') }}" class="btn btn-outline-light">Nouvelle analyse</a>
       </div>
     </div>
 
     <div class="step">
-      <div class="row">
-        <div class="col">
-          <div><span class="text-secondary">Mode:</span> <strong id="summaryMode"></strong></div>
-          <div><span class="text-secondary">Clé primaire:</span> <code id="summaryPK"></code></div>
-          <div class="mt-1"><span class="text-secondary">Champs d’embedding:</span> <span id="summaryFields"></span></div>
-          <div><span class="text-secondary">Algorithme:</span> <code id="summaryAlgo"></code></div>
-        </div>
-      </div>
+      <div><span class="text-secondary">Algorithme:</span> <code id="summaryAlgo"></code></div>
     </div>
 
     <div id="chart" class="step"></div>
@@ -104,7 +90,7 @@
     <div class="step">
       <h5>Résumé des clusters</h5>
       <table id="summary" class="table table-dark table-striped table-sm">
-        <thead><tr><th>Cluster</th><th>Items</th></tr></thead>
+        <thead><tr><th>Cluster</th><th>Nom</th><th>Items</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- Split the application into distinct generation and clustering pages
- Allow previewing API data and transcripts before embedding generation
- Support clustering from uploaded or previously generated embeddings and name clusters automatically

## Testing
- `python -m py_compile app.py indexation/helpers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a460d1e928832e9bd40ea52be5dea1