### PR TITLE
feat(api): add Pydantic response models and unify error shapes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,24 +1,35 @@
 from __future__ import annotations
 
-from fastapi import FastAPI, Request
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import HTMLResponse, FileResponse
 import logging
 
-from .routers.common import router as common_router
-from .routers.generate import router as generate_router      # kept (dataset legacy)
-from .routers.cluster import router as cluster_router        # kept (legacy clustering)
-from .routers.clip import router as clip_router              # NEW: clips flow + batch zips
-from .routers.cluster_zip import router as cluster_zip_router# NEW: cluster from zips
-from .routers.datasets import router as datasets_router        # NEW: datasets CRUD
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.staticfiles import StaticFiles
+
 from .config import BASE_DIR
-from .routers.db import router as db_router                  # NEW: DB CRUD
 from .db import init_db
+from .routers.clip import router as clip_router  # NEW: clips flow + batch zips
+from .routers.cluster import router as cluster_router  # kept (legacy clustering)
+from .routers.cluster_zip import router as cluster_zip_router  # NEW: cluster from zips
+from .routers.common import router as common_router
+from .routers.datasets import router as datasets_router  # NEW: datasets CRUD
+from .routers.db import router as db_router  # NEW: DB CRUD
+from .routers.generate import router as generate_router  # kept (dataset legacy)
 
 logger = logging.getLogger("uvicorn.error")
 
-app = FastAPI(title="Indexation v3", version="3.0.0")
+tags_metadata = [
+    {"name": "common", "description": "Health checks and helpers"},
+    {"name": "generate", "description": "Legacy dataset generation"},
+    {"name": "cluster", "description": "Legacy clustering endpoints"},
+    {"name": "clips", "description": "Clip segmentation workflow"},
+    {"name": "cluster-zips", "description": "Cluster embeddings from uploaded ZIPs"},
+    {"name": "datasets", "description": "Dataset CRUD operations"},
+    {"name": "db", "description": "Project and library database"},
+]
+
+app = FastAPI(title="Indexation v3", version="3.0.0", openapi_tags=tags_metadata)
 
 app.add_middleware(
     CORSMiddleware,
@@ -28,6 +39,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 @app.middleware("http")
 async def log_errors(request: Request, call_next):
     try:
@@ -35,6 +47,7 @@ async def log_errors(request: Request, call_next):
     except Exception:
         logger.exception("Unhandled error for %s %s", request.method, request.url)
         raise
+
 
 app.include_router(common_router, prefix="/api", tags=["common"])
 app.include_router(generate_router, prefix="/api", tags=["generate"])
@@ -46,9 +59,11 @@ app.include_router(db_router, prefix="/api/db", tags=["db"])
 
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 
+
 @app.get("/", response_class=HTMLResponse)
 def index():
     return FileResponse(str(BASE_DIR / "static" / "index.html"))
+
 
 @app.on_event("startup")
 def _startup():

--- a/app/routers/clip.py
+++ b/app/routers/clip.py
@@ -1,29 +1,42 @@
 from __future__ import annotations
 
-import io
+import asyncio
 import json
-import uuid
+import threading
 import zipfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
-import numpy as np
 import pandas as pd
-import threading, asyncio
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Form, UploadFile, File
-from ..services.jobs import new_job, set_status, set_result, get_job
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from sqlmodel import Session, select
 
-from ..config import DATA_DIR, CLIP_KEEP_RATIO_DEFAULT
+from ..config import CLIP_KEEP_RATIO_DEFAULT, DATA_DIR
+from ..db import engine
+from ..models import Artifact, Clip, Program, Project, Run
+from ..schemas import (
+    BatchLaunchResponse,
+    ErrorResponse,
+    JobStatusResponse,
+    NamedSegmentsResponse,
+    SegmentPrepareResponse,
+    SegmentPreviewResponse,
+)
 from ..services.api_client import fetch_all_programs
+from ..services.clipmaker import (
+    embed_clips,
+    make_zip_for_program,
+    program_embedding,
+    segment_text,
+)
+from ..services.jobs import get_job, new_job, set_result, set_status
+from ..services.preview_cache import get_preview, pop_preview
 from ..services.transcripts import load_transcripts
 from ..services.utils import get_nested_value
-from ..services.clipmaker import segment_text, embed_clips, program_embedding, make_zip_for_program
-from ..services.preview_cache import get_preview, pop_preview
-from ..db import engine
-from sqlmodel import Session, select
-from ..models import Project, Program, Clip, Run, Artifact
 
 router = APIRouter()
+
+ERROR_RESPONSES = {400: {"model": ErrorResponse}, 404: {"model": ErrorResponse}}
 
 
 def _read_ids_frame(tmp: Path) -> pd.DataFrame:
@@ -35,7 +48,9 @@ def _read_ids_frame(tmp: Path) -> pd.DataFrame:
     return df_ids
 
 
-@router.post("/segment/prepare")
+@router.post(
+    "/segment/prepare", response_model=SegmentPrepareResponse, responses=ERROR_RESPONSES
+)
 async def prepare_dataset(
     mode: str = Form("api"),
     primary_key: str = Form(...),
@@ -51,10 +66,14 @@ async def prepare_dataset(
 
     df = pd.DataFrame(programs)
     if "." in primary_key or primary_key not in df.columns:
-        df["_pk"] = df.apply(lambda r: get_nested_value(r.to_dict(), primary_key), axis=1)
+        df["_pk"] = df.apply(
+            lambda r: get_nested_value(r.to_dict(), primary_key), axis=1
+        )
         pk_col = "_pk"
         if df[pk_col].astype(str).str.strip().eq("").all():
-            raise HTTPException(400, f"Primary key '{primary_key}' not found in API data.")
+            raise HTTPException(
+                400, f"Primary key '{primary_key}' not found in API data."
+            )
     else:
         pk_col = primary_key
 
@@ -62,11 +81,15 @@ async def prepare_dataset(
     if mode == "excel":
         info = get_preview(excel_token or "")
         if not info or not Path(info["path"]).exists():
-            raise HTTPException(400, "Uploaded Excel token expired; please re-upload the file.")
+            raise HTTPException(
+                400, "Uploaded Excel token expired; please re-upload the file."
+            )
         tmp = Path(info["path"])
         df_ids = _read_ids_frame(tmp)
         if excel_id_col and excel_id_col not in df_ids.columns:
-            raise HTTPException(400, f"Column '{excel_id_col}' not found in uploaded file")
+            raise HTTPException(
+                400, f"Column '{excel_id_col}' not found in uploaded file"
+            )
         id_col = excel_id_col or df_ids.columns[0]
         wanted_ids = set(df_ids[id_col].astype(str).str.strip().tolist())
 
@@ -85,11 +108,16 @@ async def prepare_dataset(
         "count_included": int(len(included)),
         "count_excluded": int(len(excluded)),
         "excluded_ids": excluded[:200],  # cap in response
-        "sample_ids": included[pk_col].astype(str).head(50).tolist(),  # for preview dropdown
+        "sample_ids": included[pk_col]
+        .astype(str)
+        .head(50)
+        .tolist(),  # for preview dropdown
     }
 
 
-@router.post("/segment/preview")
+@router.post(
+    "/segment/preview", response_model=SegmentPreviewResponse, responses=ERROR_RESPONSES
+)
 async def preview_one(
     mode: str = Form("api"),
     primary_key: str = Form(...),
@@ -106,7 +134,9 @@ async def preview_one(
     programs = fetch_all_programs()
     df = pd.DataFrame(programs)
     if "." in primary_key or primary_key not in df.columns:
-        df["_pk"] = df.apply(lambda r: get_nested_value(r.to_dict(), primary_key), axis=1)
+        df["_pk"] = df.apply(
+            lambda r: get_nested_value(r.to_dict(), primary_key), axis=1
+        )
         pk_col = "_pk"
     else:
         pk_col = primary_key
@@ -115,7 +145,9 @@ async def preview_one(
     if mode == "excel":
         info = get_preview(excel_token or "")
         if not info or not Path(info["path"]).exists():
-            raise HTTPException(400, "Uploaded Excel token expired; please re-upload the file.")
+            raise HTTPException(
+                400, "Uploaded Excel token expired; please re-upload the file."
+            )
         tmp = Path(info["path"])
         df_ids = _read_ids_frame(tmp)
         id_col = excel_id_col or df_ids.columns[0]
@@ -130,28 +162,35 @@ async def preview_one(
 
     row = df[df[pk_col].astype(str) == str(sample_pk_value)].head(1)
     if row.empty:
-        raise HTTPException(400, "Sample ID not found among included items or has no transcript.")
+        raise HTTPException(
+            400, "Sample ID not found among included items or has no transcript."
+        )
 
     program_row = row.iloc[0].to_dict()
     transcript_text = program_row.get("__tx", "").strip()
     if not transcript_text:
         raise HTTPException(400, "No transcript attached for this ID.")
 
-    segments = await segment_text(transcript_text, keep_ratio=keep_ratio, with_titles=with_titles, brief=brief)
+    segments = await segment_text(
+        transcript_text, keep_ratio=keep_ratio, with_titles=with_titles, brief=brief
+    )
     clip_embs = await embed_clips(segments)
-    prog_emb  = await program_embedding(program_row, primary_key, embed_fields, segments)
+    prog_emb = await program_embedding(program_row, primary_key, embed_fields, segments)
 
     # compact preview payload (truncate text)
     preview = []
     for s in segments[:20]:
-        preview.append({
-            "start": s.get("start"),
-            "end": s.get("end"),
-            "score": round(float(s.get("score", 0)), 3),
-            "title": s.get("title"),
-            "summary": s.get("summary"),
-            "text": (s.get("text") or "")[:600] + ("…" if len(s.get("text","")) > 600 else "")
-        })
+        preview.append(
+            {
+                "start": s.get("start"),
+                "end": s.get("end"),
+                "score": round(float(s.get("score", 0)), 3),
+                "title": s.get("title"),
+                "summary": s.get("summary"),
+                "text": (s.get("text") or "")[:600]
+                + ("…" if len(s.get("text", "")) > 600 else ""),
+            }
+        )
     return {
         "pk_value": str(sample_pk_value),
         "segments": preview,
@@ -161,7 +200,9 @@ async def preview_one(
     }
 
 
-@router.post("/segment/name")
+@router.post(
+    "/segment/name", response_model=NamedSegmentsResponse, responses=ERROR_RESPONSES
+)
 async def name_segments(
     segments_json: str = Form(...),
 ):
@@ -177,6 +218,7 @@ async def name_segments(
         t, su = "Segment", ""
         try:
             from ..services.clipmaker import _summarize_fr  # reuse summarizer
+
             t, su = _summarize_fr(s.get("text", ""))
         except Exception:
             pass
@@ -187,7 +229,9 @@ async def name_segments(
     return {"segments": named}
 
 
-@router.post("/segment/batch")
+@router.post(
+    "/segment/batch", response_model=BatchLaunchResponse, responses=ERROR_RESPONSES
+)
 async def batch_zip(
     mode: str = Form("api"),
     primary_key: str = Form(...),
@@ -206,7 +250,9 @@ async def batch_zip(
     programs = fetch_all_programs()
     df = pd.DataFrame(programs)
     if "." in primary_key or primary_key not in df.columns:
-        df["_pk"] = df.apply(lambda r: get_nested_value(r.to_dict(), primary_key), axis=1)
+        df["_pk"] = df.apply(
+            lambda r: get_nested_value(r.to_dict(), primary_key), axis=1
+        )
         pk_col = "_pk"
     else:
         pk_col = primary_key
@@ -215,7 +261,9 @@ async def batch_zip(
     if mode == "excel":
         info = pop_preview(excel_token or "")
         if not info or not Path(info["path"]).exists():
-            raise HTTPException(400, "Uploaded Excel token expired; please re-upload the file.")
+            raise HTTPException(
+                400, "Uploaded Excel token expired; please re-upload the file."
+            )
         tmp = Path(info["path"])
         df_ids = _read_ids_frame(tmp)
         try:
@@ -240,12 +288,40 @@ async def batch_zip(
     uid = new_job()
     set_status(uid, "queued")
     # 🔑 Launch in a real background thread (pass transcript names too + project info)
-    _start_batch_thread(uid, df, pk_col, primary_key, embed_fields, keep_ratio, brief, with_titles, t_map, t_name, mode, excel_id_col, project_name)
+    _start_batch_thread(
+        uid,
+        df,
+        pk_col,
+        primary_key,
+        embed_fields,
+        keep_ratio,
+        brief,
+        with_titles,
+        t_map,
+        t_name,
+        mode,
+        excel_id_col,
+        project_name,
+    )
     # respond immediately; front-end will poll /segment/status/{uid}
     return {"uid": uid, "status": "queued"}
 
 
-async def _run_batch_async(uid, df, pk_col, primary_key, embed_fields, keep_ratio, brief, with_titles, t_map, t_name, mode, excel_id_col, project_name):
+async def _run_batch_async(
+    uid,
+    df,
+    pk_col,
+    primary_key,
+    embed_fields,
+    keep_ratio,
+    brief,
+    with_titles,
+    t_map,
+    t_name,
+    mode,
+    excel_id_col,
+    project_name,
+):
     try:
         total = len(df)
         set_status(uid, "running", f"starting… 0/{total}")
@@ -264,9 +340,13 @@ async def _run_batch_async(uid, df, pk_col, primary_key, embed_fields, keep_rati
                 mode=mode,
                 excel_id_col=(excel_id_col or None),
             )
-            ses.add(proj); ses.commit(); ses.refresh(proj)
+            ses.add(proj)
+            ses.commit()
+            ses.refresh(proj)
             run = Run(project_id=proj.id, uid=uid, status="running", note=f"0/{total}")
-            ses.add(run); ses.commit(); ses.refresh(run)
+            ses.add(run)
+            ses.commit()
+            ses.refresh(run)
 
         zip_paths = []
         manifest = []
@@ -278,46 +358,71 @@ async def _run_batch_async(uid, df, pk_col, primary_key, embed_fields, keep_rati
                 set_status(uid, "running", f"skip (no transcript) {i}/{total}")
                 await asyncio.sleep(0)
                 continue
-            segs = await segment_text(tx, keep_ratio=keep_ratio, with_titles=with_titles, brief=brief)
-            if not segs: 
+            segs = await segment_text(
+                tx, keep_ratio=keep_ratio, with_titles=with_titles, brief=brief
+            )
+            if not segs:
                 continue
             clip_embs = await embed_clips(segs)
-            prog_emb  = await program_embedding(row, primary_key, embed_fields, segs)
-            zpath = make_zip_for_program(uid, pk_value, row, primary_key, embed_fields, segs, clip_embs, prog_emb)
+            prog_emb = await program_embedding(row, primary_key, embed_fields, segs)
+            zpath = make_zip_for_program(
+                uid, pk_value, row, primary_key, embed_fields, segs, clip_embs, prog_emb
+            )
             zip_paths.append(zpath)
-            manifest.append({"uid": uid, "pk": pk_value, "num_clips": len(segs), "zip": Path(zpath).name})
+            manifest.append(
+                {
+                    "uid": uid,
+                    "pk": pk_value,
+                    "num_clips": len(segs),
+                    "zip": Path(zpath).name,
+                }
+            )
             # Persist to DB
             with Session(engine) as ses:
                 # store program meta snapshot + transcript
                 fields = {f: get_nested_value(row, f) for f in embed_fields}
                 prog = Program(
-                    project_id=proj.id, pk_value=pk_value,
+                    project_id=proj.id,
+                    pk_value=pk_value,
                     fields_json=fields,
                     transcript_name=t_name.get(pk_value) if t_name else None,
                     transcript_text=tx,
                     num_clips=len(segs),
                     last_zip_path=f"/api/download/zips/{uid}/{Path(zpath).name}",
                 )
-                ses.add(prog); ses.commit(); ses.refresh(prog)
+                ses.add(prog)
+                ses.commit()
+                ses.refresh(prog)
                 for j, s in enumerate(segs, start=1):
-                    ses.add(Clip(
-                        program_id=prog.id, idx=j,
-                        start=s.get("start"), end=s.get("end"),
-                        score=float(s.get("score", 0.0)),
-                        title=s.get("title"), summary=s.get("summary"), text=s.get("text")
-                    ))
+                    ses.add(
+                        Clip(
+                            program_id=prog.id,
+                            idx=j,
+                            start=s.get("start"),
+                            end=s.get("end"),
+                            score=float(s.get("score", 0.0)),
+                            title=s.get("title"),
+                            summary=s.get("summary"),
+                            text=s.get("text"),
+                        )
+                    )
                 ses.commit()
             set_status(uid, "running", f"processed {i}/{total}")
             await asyncio.sleep(0)  # tiny yield back to loop
 
         master_path = DATA_DIR / "zips" / f"{uid}.zip"
-        with zipfile.ZipFile(master_path, "w", compression=zipfile.ZIP_DEFLATED) as master:
+        with zipfile.ZipFile(
+            master_path, "w", compression=zipfile.ZIP_DEFLATED
+        ) as master:
             for p in zip_paths:
                 master.write(p, arcname=Path(p).name)
             if manifest:
                 import io
+
                 import pandas as pd
-                buf = io.StringIO(); pd.DataFrame(manifest).to_csv(buf, index=False)
+
+                buf = io.StringIO()
+                pd.DataFrame(manifest).to_csv(buf, index=False)
                 master.writestr("manifest.csv", buf.getvalue())
         # Save artifacts + finalize run
         with Session(engine) as ses:
@@ -326,25 +431,65 @@ async def _run_batch_async(uid, df, pk_col, primary_key, embed_fields, keep_rati
                 run.status = "done"
                 run.note = f"{len(zip_paths)}/{total} processed"
                 run.master_zip_path = f"/api/download/zips/{master_path.name}"
-                ses.add(run); ses.commit()
-                ses.add(Artifact(run_id=run.id, kind="zip", path=str(master_path))); ses.commit()
+                ses.add(run)
+                ses.commit()
+                ses.add(Artifact(run_id=run.id, kind="zip", path=str(master_path)))
+                ses.commit()
 
-        set_result(uid, {
-            "uid": uid,
-            "count": len(zip_paths),
-            "master_zip": f"/api/download/zips/{master_path.name}",
-            "zips": [f"/api/download/zips/{uid}/{Path(p).name}" for p in zip_paths],
-        })
+        set_result(
+            uid,
+            {
+                "uid": uid,
+                "count": len(zip_paths),
+                "master_zip": f"/api/download/zips/{master_path.name}",
+                "zips": [f"/api/download/zips/{uid}/{Path(p).name}" for p in zip_paths],
+            },
+        )
     except Exception as e:
         set_status(uid, "error", str(e))
 
-def _start_batch_thread(uid, df, pk_col, primary_key, embed_fields, keep_ratio, brief, with_titles, t_map, t_name, mode, excel_id_col, project_name):
+
+def _start_batch_thread(
+    uid,
+    df,
+    pk_col,
+    primary_key,
+    embed_fields,
+    keep_ratio,
+    brief,
+    with_titles,
+    t_map,
+    t_name,
+    mode,
+    excel_id_col,
+    project_name,
+):
     def runner():
         # new thread → safe to create and run a private event loop
-        asyncio.run(_run_batch_async(uid, df, pk_col, primary_key, embed_fields, keep_ratio, brief, with_titles, t_map, t_name, mode, excel_id_col, project_name))
+        asyncio.run(
+            _run_batch_async(
+                uid,
+                df,
+                pk_col,
+                primary_key,
+                embed_fields,
+                keep_ratio,
+                brief,
+                with_titles,
+                t_map,
+                t_name,
+                mode,
+                excel_id_col,
+                project_name,
+            )
+        )
+
     t = threading.Thread(target=runner, name=f"batch-{uid}", daemon=True)
     t.start()
 
-@router.get("/segment/status/{uid}")
+
+@router.get(
+    "/segment/status/{uid}", response_model=JobStatusResponse, responses=ERROR_RESPONSES
+)
 async def batch_status(uid: str):
     return get_job(uid)

--- a/app/routers/cluster.py
+++ b/app/routers/cluster.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
-import json
 import uuid
 from typing import Optional
 
 import numpy as np
 import pandas as pd
-from fastapi import APIRouter, Form, UploadFile, File, HTTPException
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 
-from ..config import DATA_DIR, TITLE_COL_CANDIDATES, PROJECTION_DEFAULT
+from ..config import DATA_DIR, PROJECTION_DEFAULT, TITLE_COL_CANDIDATES
+from ..schemas import ClusterResponse, ErrorResponse
 from ..services.clustering import auto_kmeans, pca_2d, tsne_2d
 from ..services.embeddings import suggest_cluster_names  # reuse helper for naming
 
 router = APIRouter()
 
-@router.post("/cluster")
+ERROR_RESPONSES = {400: {"model": ErrorResponse}, 404: {"model": ErrorResponse}}
+
+
+@router.post("/cluster", response_model=ClusterResponse, responses=ERROR_RESPONSES)
 async def run_cluster(
     existing_uid: Optional[str] = Form(None),
     k_choice: str = Form("auto"),
@@ -32,7 +35,9 @@ async def run_cluster(
             raise HTTPException(400, "Selected dataset not found.")
     else:
         if not dataset_file or not embedding_file:
-            raise HTTPException(400, "Provide dataset (.parquet) and embeddings (.npy).")
+            raise HTTPException(
+                400, "Provide dataset (.parquet) and embeddings (.npy)."
+            )
         uid = uuid.uuid4().hex[:8]
         df_path = DATA_DIR / f"upload_{uid}.parquet"
         emb_path = DATA_DIR / f"upload_{uid}.npy"
@@ -47,6 +52,7 @@ async def run_cluster(
     # Clustering
     if algo_choice == "dbscan":
         from sklearn.cluster import DBSCAN
+
         try:
             db = DBSCAN(eps=float(db_eps), min_samples=int(db_min_samples))
         except Exception:
@@ -60,6 +66,7 @@ async def run_cluster(
         else:
             from sklearn.cluster import KMeans
             from sklearn.metrics import silhouette_score
+
             try:
                 k = int(k_choice)
                 km = KMeans(n_clusters=k, n_init=10, random_state=42)
@@ -100,6 +107,9 @@ async def run_cluster(
             }
             for idx, row in df.iterrows()
         ],
-        "download": {"parquet": f"/api/download/{out_name}", "embeddings": f"/api/download/{emb_path.name}"},
+        "download": {
+            "parquet": f"/api/download/{out_name}",
+            "embeddings": f"/api/download/{emb_path.name}",
+        },
     }
     return payload

--- a/app/routers/cluster_zip.py
+++ b/app/routers/cluster_zip.py
@@ -3,16 +3,17 @@ from __future__ import annotations
 import io
 import json
 import zipfile
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import numpy as np
-import pandas as pd
-from fastapi import APIRouter, Form, UploadFile, File, HTTPException
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 
-from ..services.clustering import project_points, kmeans_auto_or_k, dbscan_cluster
-from ..config import DATA_DIR
+from ..schemas import ClusterZipResponse, ErrorResponse
+from ..services.clustering import dbscan_cluster, kmeans_auto_or_k, project_points
 
 router = APIRouter()
+
+ERROR_RESPONSES = {400: {"model": ErrorResponse}, 404: {"model": ErrorResponse}}
 
 
 def _read_npy_from_zip(zf: zipfile.ZipFile, name: str) -> np.ndarray:
@@ -32,7 +33,9 @@ def _read_lines_from_zip(zf: zipfile.ZipFile, name: str) -> List[Dict[str, Any]]
     return lines
 
 
-@router.post("/cluster/clips")
+@router.post(
+    "/cluster/clips", response_model=ClusterZipResponse, responses=ERROR_RESPONSES
+)
 async def cluster_clips(
     packages: List[UploadFile] = File(...),
     algo_choice: str = Form("kmeans"),  # kmeans|dbscan
@@ -61,7 +64,15 @@ async def cluster_clips(
             texts = [m.get("text") for m in meta] if meta else [None] * emb.shape[0]
 
             for i in range(emb.shape[0]):
-                rows.append({"pk": pk, "idx": i + 1, "title": titles[i], "text": texts[i], "vec": emb[i, :]})
+                rows.append(
+                    {
+                        "pk": pk,
+                        "idx": i + 1,
+                        "title": titles[i],
+                        "text": texts[i],
+                        "vec": emb[i, :],
+                    }
+                )
 
     if not rows:
         raise HTTPException(400, "No clips found in uploaded ZIPs.")
@@ -78,26 +89,30 @@ async def cluster_clips(
     proj = project_points(X, proj_choice)
     points = []
     for r, c, xy in zip(rows, labels, proj):
-        points.append({
-            "pk": r["pk"],
-            "clip_index": r["idx"],
-            "title": r["title"],
-            "cluster": int(c),
-            "x": float(xy[0]),
-            "y": float(xy[1]),
-        })
+        points.append(
+            {
+                "pk": r["pk"],
+                "clip_index": r["idx"],
+                "title": r["title"],
+                "cluster": int(c),
+                "x": float(xy[0]),
+                "y": float(xy[1]),
+            }
+        )
 
     meta = {"k": k, "silhouette": sil, "cluster_names": {}}
     if name_clusters and k > 0:
         # optional: name clusters using titles as exemplars
         try:
-            from ..services.embeddings import name_clusters_via_chat  # if you add later
+            pass  # if you add later
         except Exception:
             meta["cluster_names"] = {}
     return {"points": points, "meta": meta, "download": {}}
 
 
-@router.post("/cluster/emissions")
+@router.post(
+    "/cluster/emissions", response_model=ClusterZipResponse, responses=ERROR_RESPONSES
+)
 async def cluster_emissions(
     packages: List[UploadFile] = File(...),
     algo_choice: str = Form("kmeans"),
@@ -116,7 +131,9 @@ async def cluster_emissions(
             try:
                 emb = _read_npy_from_zip(zf, "emb_program.npy")
             except KeyError:
-                raise HTTPException(400, f"{p.filename} does not contain emb_program.npy")
+                raise HTTPException(
+                    400, f"{p.filename} does not contain emb_program.npy"
+                )
             program_meta = json.loads(zf.read("program.json").decode("utf-8"))
             pk = str(program_meta.get("pk_value"))
             rows.append({"pk": pk, "vec": emb})
@@ -136,7 +153,9 @@ async def cluster_emissions(
     proj = project_points(X, proj_choice)
     points = []
     for r, c, xy in zip(rows, labels, proj):
-        points.append({"pk": r["pk"], "cluster": int(c), "x": float(xy[0]), "y": float(xy[1])})
+        points.append(
+            {"pk": r["pk"], "cluster": int(c), "x": float(xy[0]), "y": float(xy[1])}
+        )
 
     meta = {"k": k, "silhouette": sil, "cluster_names": {}}
     return {"points": points, "meta": meta, "download": {}}

--- a/app/routers/common.py
+++ b/app/routers/common.py
@@ -1,34 +1,42 @@
 from __future__ import annotations
 
 import subprocess
-from fastapi import APIRouter, UploadFile, HTTPException, File
-from fastapi.responses import FileResponse
 from pathlib import Path
+
 import pandas as pd
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
 
 from ..config import API_BASE, DATA_DIR
-from ..services.preview_cache import register_preview, cleanup_previews
+from ..schemas import ErrorResponse, FieldsResponse
 from ..services.api_client import discover_fields
+from ..services.preview_cache import cleanup_previews, register_preview
 
 router = APIRouter()
+
+ERROR_RESPONSES = {400: {"model": ErrorResponse}, 404: {"model": ErrorResponse}}
 
 
 @router.get("/health")
 def health():
     try:
-        sha = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode().strip()
+        sha = (
+            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+            .decode()
+            .strip()
+        )
     except Exception:
         sha = "unknown"
     return {"ok": True, "version": sha}
 
 
-@router.get("/fields")
+@router.get("/fields", response_model=FieldsResponse, responses=ERROR_RESPONSES)
 def api_fields():
     fields, source, sample_size, err = discover_fields()
     payload = {
         "fields": fields,
         "api_base": API_BASE,
-        "source": source,            # 'direct' | 'fallback' | 'empty'
+        "source": source,  # 'direct' | 'fallback' | 'empty'
         "sample_size": sample_size,  # number of items inspected
     }
     if err:

--- a/app/routers/datasets.py
+++ b/app/routers/datasets.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -11,12 +11,17 @@ from sqlmodel import Session, select
 
 from ..db import get_session
 from ..models import Dataset
+from ..schemas import DatasetInfo, ErrorResponse
 from ..services.api_client import fetch_all_programs
 from ..services.embeddings import batch_embed, build_text_from_fields
 from ..services.storage import save_dataset_files
 from ..services.utils import get_nested_value
 
 router = APIRouter()
+
+ERROR_RESPONSES = {400: {"model": ErrorResponse}, 404: {"model": ErrorResponse}}
+
+
 def _ds_to_dict(ds: Dataset) -> dict:
     return {
         "uid": ds.uid,
@@ -32,12 +37,13 @@ class DatasetUpdate(BaseModel):
     label: Optional[str] = None
 
 
-@router.get("/datasets")
+@router.get("/datasets", response_model=List[DatasetInfo], responses=ERROR_RESPONSES)
 def list_datasets(session: Session = Depends(get_session)):
     rows = session.exec(select(Dataset).order_by(Dataset.created_at.desc())).all()
     return [_ds_to_dict(d) for d in rows]
 
-@router.get("/datasets/{uid}")
+
+@router.get("/datasets/{uid}", response_model=DatasetInfo, responses=ERROR_RESPONSES)
 def get_dataset(uid: str, session: Session = Depends(get_session)):
     ds = session.get(Dataset, uid)
     if not ds:
@@ -45,9 +51,10 @@ def get_dataset(uid: str, session: Session = Depends(get_session)):
     return _ds_to_dict(ds)
 
 
-
-@router.put("/datasets/{uid}")
-def update_dataset(uid: str, payload: DatasetUpdate, session: Session = Depends(get_session)):
+@router.put("/datasets/{uid}", response_model=DatasetInfo, responses=ERROR_RESPONSES)
+def update_dataset(
+    uid: str, payload: DatasetUpdate, session: Session = Depends(get_session)
+):
     ds = session.get(Dataset, uid)
     if not ds:
         raise HTTPException(404, "Not found")
@@ -58,7 +65,7 @@ def update_dataset(uid: str, payload: DatasetUpdate, session: Session = Depends(
     return _ds_to_dict(ds)
 
 
-@router.delete("/datasets/{uid}", status_code=204)
+@router.delete("/datasets/{uid}", status_code=204, responses=ERROR_RESPONSES)
 def delete_dataset(uid: str, session: Session = Depends(get_session)):
     ds = session.get(Dataset, uid)
     if not ds:
@@ -68,7 +75,9 @@ def delete_dataset(uid: str, session: Session = Depends(get_session)):
     return
 
 
-@router.post("/datasets/{uid}/rerun")
+@router.post(
+    "/datasets/{uid}/rerun", response_model=DatasetInfo, responses=ERROR_RESPONSES
+)
 async def rerun_dataset(uid: str, session: Session = Depends(get_session)):
     ds = session.get(Dataset, uid)
     if not ds:
@@ -87,11 +96,15 @@ async def rerun_dataset(uid: str, session: Session = Depends(get_session)):
         raise HTTPException(400, "The catalog API returned no data.")
     df = pd.DataFrame(programs)
     if "." in primary_key or primary_key not in df.columns:
-        df["_pk"] = df.apply(lambda r: get_nested_value(r.to_dict(), primary_key), axis=1)
+        df["_pk"] = df.apply(
+            lambda r: get_nested_value(r.to_dict(), primary_key), axis=1
+        )
         pk_col = "_pk"
     else:
         pk_col = primary_key
-    texts = [build_text_from_fields(row.to_dict(), embed_fields) for _, row in df.iterrows()]
+    texts = [
+        build_text_from_fields(row.to_dict(), embed_fields) for _, row in df.iterrows()
+    ]
     df["_text_for_embedding"] = texts
     df = df[df["_text_for_embedding"].astype(str).str.strip() != ""]
     if df.empty:
@@ -100,7 +113,9 @@ async def rerun_dataset(uid: str, session: Session = Depends(get_session)):
     X = np.vstack(embs)
     new_uid = str(uuid.uuid4())[:8]
     raw_name, emb_name = save_dataset_files(df, X, new_uid)
-    new_ds = Dataset(uid=new_uid, raw_path=raw_name, emb_path=emb_name, config=cfg, label=ds.label)
+    new_ds = Dataset(
+        uid=new_uid, raw_path=raw_name, emb_path=emb_name, config=cfg, label=ds.label
+    )
     session.add(new_ds)
     session.commit()
     session.refresh(new_ds)

--- a/app/routers/db.py
+++ b/app/routers/db.py
@@ -1,25 +1,37 @@
 from __future__ import annotations
 
-import json
 import uuid
-from typing import Optional
 from pathlib import Path
+from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Body
-from sqlmodel import Session, select, delete
+from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy import func
+from sqlmodel import Session, delete, select
 
-
-from ..db import get_session, engine
-from ..models import Project, Program, Clip, Run, Artifact
-from ..services.utils import get_nested_value
-from ..services.clipmaker import segment_text, embed_clips, program_embedding, make_zip_for_program
-from ..config import DATA_DIR
+from ..db import get_session
+from ..models import Clip, Program, Project
+from ..schemas import (
+    ClipUpdateResponse,
+    ErrorResponse,
+    ProgramDetailResponse,
+    ProgramRerunResponse,
+    ProgramsResponse,
+    ProjectsResponse,
+)
+from ..services.clipmaker import (
+    embed_clips,
+    make_zip_for_program,
+    program_embedding,
+    segment_text,
+)
 
 router = APIRouter()
 
+ERROR_RESPONSES = {400: {"model": ErrorResponse}, 404: {"model": ErrorResponse}}
+
+
 # ---------- Projects ----------
-@router.get("/projects")
+@router.get("/projects", response_model=ProjectsResponse, responses=ERROR_RESPONSES)
 def list_projects(session: Session = Depends(get_session)):
     projects = session.exec(select(Project).order_by(Project.created_at.desc())).all()
     rows = []
@@ -28,30 +40,57 @@ def list_projects(session: Session = Depends(get_session)):
             select(func.count()).select_from(Program).where(Program.project_id == p.id)
         ).scalar_one()[0]
 
-        rows.append({
-            "id": p.id, "name": p.name, "created_at": p.created_at.isoformat(),
-            "primary_key": p.primary_key, "embed_fields": p.embed_fields,
-            "keep_ratio": p.keep_ratio, "with_titles": p.with_titles, "brief": p.brief,
-            "mode": p.mode, "excel_id_col": p.excel_id_col,
-            "programs": n,
-        })
+        rows.append(
+            {
+                "id": p.id,
+                "name": p.name,
+                "created_at": p.created_at.isoformat(),
+                "primary_key": p.primary_key,
+                "embed_fields": p.embed_fields,
+                "keep_ratio": p.keep_ratio,
+                "with_titles": p.with_titles,
+                "brief": p.brief,
+                "mode": p.mode,
+                "excel_id_col": p.excel_id_col,
+                "programs": n,
+            }
+        )
     return {"projects": rows}
 
-# ---------- Programs ----------
-@router.get("/programs")
-def list_programs(project_id: int, session: Session = Depends(get_session)):
-    progs = session.exec(select(Program).where(Program.project_id == project_id).order_by(Program.pk_value)).all()
-    return {"programs": [
-        {"id": pr.id, "pk_value": pr.pk_value, "num_clips": pr.num_clips, "last_zip_path": pr.last_zip_path}
-        for pr in progs
-    ]}
 
-@router.get("/programs/{program_id}")
+# ---------- Programs ----------
+@router.get("/programs", response_model=ProgramsResponse, responses=ERROR_RESPONSES)
+def list_programs(project_id: int, session: Session = Depends(get_session)):
+    progs = session.exec(
+        select(Program)
+        .where(Program.project_id == project_id)
+        .order_by(Program.pk_value)
+    ).all()
+    return {
+        "programs": [
+            {
+                "id": pr.id,
+                "pk_value": pr.pk_value,
+                "num_clips": pr.num_clips,
+                "last_zip_path": pr.last_zip_path,
+            }
+            for pr in progs
+        ]
+    }
+
+
+@router.get(
+    "/programs/{program_id}",
+    response_model=ProgramDetailResponse,
+    responses=ERROR_RESPONSES,
+)
 def get_program(program_id: int, session: Session = Depends(get_session)):
     pr = session.get(Program, program_id)
     if not pr:
         raise HTTPException(404, "Program not found")
-    clips = session.exec(select(Clip).where(Clip.program_id == program_id).order_by(Clip.idx)).all()
+    clips = session.exec(
+        select(Clip).where(Clip.program_id == program_id).order_by(Clip.idx)
+    ).all()
     return {
         "program": {
             "id": pr.id,
@@ -63,14 +102,25 @@ def get_program(program_id: int, session: Session = Depends(get_session)):
             "last_zip_path": pr.last_zip_path,
         },
         "clips": [
-            {"id": c.id, "idx": c.idx, "start": c.start, "end": c.end, "score": c.score,
-             "title": c.title, "summary": c.summary, "text": c.text}
+            {
+                "id": c.id,
+                "idx": c.idx,
+                "start": c.start,
+                "end": c.end,
+                "score": c.score,
+                "title": c.title,
+                "summary": c.summary,
+                "text": c.text,
+            }
             for c in clips
-        ]
+        ],
     }
 
+
 # ---------- Clips ----------
-@router.patch("/clips/{clip_id}")
+@router.patch(
+    "/clips/{clip_id}", response_model=ClipUpdateResponse, responses=ERROR_RESPONSES
+)
 def update_clip(
     clip_id: int,
     payload: dict = Body(...),
@@ -85,10 +135,24 @@ def update_clip(
     session.add(c)
     session.commit()
     session.refresh(c)
-    return {"ok": True, "clip": {"id": c.id, "idx": c.idx, "title": c.title, "summary": c.summary, "score": c.score}}
+    return {
+        "ok": True,
+        "clip": {
+            "id": c.id,
+            "idx": c.idx,
+            "title": c.title,
+            "summary": c.summary,
+            "score": c.score,
+        },
+    }
+
 
 # ---------- Rerun segmentation for one program ----------
-@router.post("/programs/{program_id}/rerun")
+@router.post(
+    "/programs/{program_id}/rerun",
+    response_model=ProgramRerunResponse,
+    responses=ERROR_RESPONSES,
+)
 async def rerun_program(
     program_id: int,
     keep_ratio: Optional[float] = Body(None),
@@ -111,28 +175,51 @@ async def rerun_program(
     eff_brief = brief if (brief is not None and brief.strip()) else project.brief
 
     # Segment → embed → program embed
-    segs = await segment_text(pr.transcript_text, keep_ratio=eff_keep, with_titles=eff_titles, brief=eff_brief)
+    segs = await segment_text(
+        pr.transcript_text, keep_ratio=eff_keep, with_titles=eff_titles, brief=eff_brief
+    )
     clip_embs = await embed_clips(segs)
     program_row = pr.fields_json or {}
-    prog_emb = await program_embedding(program_row, project.primary_key, project.embed_fields, segs)
+    prog_emb = await program_embedding(
+        program_row, project.primary_key, project.embed_fields, segs
+    )
 
     # Persist: replace old clips
     session.exec(delete(Clip).where(Clip.program_id == pr.id))
     for i, s in enumerate(segs, start=1):
-        session.add(Clip(
-            program_id=pr.id, idx=i,
-            start=s.get("start"), end=s.get("end"),
-            score=float(s.get("score", 0.0)),
-            title=s.get("title"), summary=s.get("summary"), text=s.get("text"),
-        ))
+        session.add(
+            Clip(
+                program_id=pr.id,
+                idx=i,
+                start=s.get("start"),
+                end=s.get("end"),
+                score=float(s.get("score", 0.0)),
+                title=s.get("title"),
+                summary=s.get("summary"),
+                text=s.get("text"),
+            )
+        )
     pr.num_clips = len(segs)
 
     # Export a fresh program ZIP for this rerun
     uid = "rerun-" + uuid.uuid4().hex[:6]
-    zpath = make_zip_for_program(uid, pr.pk_value, program_row, project.primary_key, project.embed_fields, segs, clip_embs, prog_emb)
+    zpath = make_zip_for_program(
+        uid,
+        pr.pk_value,
+        program_row,
+        project.primary_key,
+        project.embed_fields,
+        segs,
+        clip_embs,
+        prog_emb,
+    )
     pr.last_zip_path = f"/api/download/zips/{uid}/{Path(zpath).name}"
 
     session.add(pr)
     session.commit()
-    return {"ok": True, "program_id": pr.id, "num_clips": pr.num_clips, "zip": pr.last_zip_path}
-
+    return {
+        "ok": True,
+        "program_id": pr.id,
+        "num_clips": pr.num_clips,
+        "zip": pr.last_zip_path,
+    }

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,188 @@
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class ErrorResponse(BaseModel):
+    detail: str
+
+
+class FieldsResponse(BaseModel):
+    fields: List[str]
+    api_base: str
+    source: str
+    sample_size: int
+    note: Optional[str] = None
+
+
+class SegmentPrepareResponse(BaseModel):
+    primary_key: str
+    count_included: int
+    count_excluded: int
+    excluded_ids: List[str]
+    sample_ids: List[str]
+
+
+class ClipSegment(BaseModel):
+    start: Optional[float] = None
+    end: Optional[float] = None
+    score: Optional[float] = None
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    text: Optional[str] = None
+
+
+class SegmentPreviewResponse(BaseModel):
+    pk_value: str
+    segments: List[ClipSegment]
+    n_segments: int
+    clip_dim: int
+    has_program_embedding: bool
+
+
+class NamedSegmentsResponse(BaseModel):
+    segments: List[ClipSegment]
+
+
+class BatchLaunchResponse(BaseModel):
+    uid: str
+    status: str
+
+
+class SegmentBatchResult(BaseModel):
+    uid: str
+    count: int
+    master_zip: str
+    zips: List[str]
+
+
+class JobStatusResponse(BaseModel):
+    status: str
+    note: Optional[str] = None
+    result: Optional[SegmentBatchResult] = None
+
+
+class ClusterMeta(BaseModel):
+    k: int
+    silhouette: float
+    points: Optional[int] = None
+    algo: Optional[str] = None
+    projection: Optional[str] = None
+    cluster_names: Dict[str, Any]
+
+
+class ClusterPoint(BaseModel):
+    id: str
+    title: str
+    cluster: int
+    x: float
+    y: float
+
+
+class ClusterDownload(BaseModel):
+    parquet: str
+    embeddings: str
+
+
+class ClusterResponse(BaseModel):
+    meta: ClusterMeta
+    points: List[ClusterPoint]
+    download: ClusterDownload
+
+
+class ClusterClipPoint(BaseModel):
+    pk: str
+    clip_index: int
+    title: Optional[str] = None
+    cluster: int
+    x: float
+    y: float
+
+
+class ClusterEmissionPoint(BaseModel):
+    pk: str
+    cluster: int
+    x: float
+    y: float
+
+
+class ClusterZipResponse(BaseModel):
+    points: List[Dict[str, Any]]
+    meta: ClusterMeta
+    download: Dict[str, Any]
+
+
+class DatasetInfo(BaseModel):
+    uid: str
+    raw_path: str
+    emb_path: str
+    created_at: Optional[str] = None
+    label: Optional[str] = None
+    config: Dict[str, Any]
+
+
+class ProjectInfo(BaseModel):
+    id: int
+    name: str
+    created_at: str
+    primary_key: str
+    embed_fields: List[str]
+    keep_ratio: float
+    with_titles: bool
+    brief: Optional[str]
+    mode: str
+    excel_id_col: Optional[str]
+    programs: int
+
+
+class ProjectsResponse(BaseModel):
+    projects: List[ProjectInfo]
+
+
+class ProgramSummary(BaseModel):
+    id: int
+    pk_value: str
+    num_clips: int
+    last_zip_path: Optional[str]
+
+
+class ProgramsResponse(BaseModel):
+    programs: List[ProgramSummary]
+
+
+class ClipInfo(BaseModel):
+    id: int
+    idx: int
+    start: Optional[float] = None
+    end: Optional[float] = None
+    score: Optional[float] = None
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    text: Optional[str] = None
+
+
+class ProgramDetail(BaseModel):
+    id: int
+    project_id: int
+    pk_value: str
+    fields_json: Dict[str, Any]
+    transcript_name: Optional[str] = None
+    num_clips: int
+    last_zip_path: Optional[str] = None
+
+
+class ProgramDetailResponse(BaseModel):
+    program: ProgramDetail
+    clips: List[ClipInfo]
+
+
+class ClipUpdateResponse(BaseModel):
+    ok: bool
+    clip: Dict[str, Any]
+
+
+class ProgramRerunResponse(BaseModel):
+    ok: bool
+    program_id: int
+    num_clips: int
+    zip: str


### PR DESCRIPTION
## Summary
- define shared response schemas and error envelope
- type key endpoints across routers
- document API groups with tags and open CORS setup

## Testing
- `pre-commit run --files app/schemas.py app/routers/common.py app/routers/clip.py app/routers/cluster.py app/routers/cluster_zip.py app/routers/datasets.py app/routers/db.py app/main.py` (fails: mypy errors)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b6ed6efb98832eb1e67092f636c216