### PR TITLE
feat(web): add Settings page with health and fields discovery

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-const API_BASE = "/api";
+export const API_BASE = (import.meta.env.VITE_API_BASE as string) || "/api";
 
 export async function api<T>(
   path: string,

--- a/web/src/lib/useApi.ts
+++ b/web/src/lib/useApi.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { api } from "./api";
+
+export function useApi<T>(path: string) {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    api<T>(path)
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((e: Error) => {
+        if (!cancelled) setError(e.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [path]);
+
+  return { data, error, loading };
+}
+

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,4 +1,64 @@
+import { API_BASE } from "../lib/api";
+import { useApi } from "../lib/useApi";
+
+type HealthResponse = { ok: boolean; version: string };
+type FieldsResponse = {
+  fields: string[];
+  api_base: string;
+  source: string;
+  sample_size: number;
+  note?: string;
+};
+
 export default function Settings() {
-  return <h1 className="text-xl font-bold">Settings</h1>;
+  const {
+    data: health,
+    error: healthError,
+    loading: healthLoading,
+  } = useApi<HealthResponse>("/health");
+  const {
+    data: fields,
+    error: fieldsError,
+    loading: fieldsLoading,
+  } = useApi<FieldsResponse>("/fields");
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-bold">Settings</h1>
+
+      <section>
+        <h2 className="font-semibold">API</h2>
+        <p>
+          Base URL: <code>{API_BASE}</code>
+        </p>
+        {healthLoading && <p>Checking…</p>}
+        {healthError && <p className="text-red-600">{healthError}</p>}
+        {health && <p className="text-green-700">OK • {health.version}</p>}
+      </section>
+
+      <section>
+        <h2 className="font-semibold">Fields</h2>
+        {fieldsLoading && <p>Loading…</p>}
+        {fieldsError && <p className="text-red-600">{fieldsError}</p>}
+        {fields && (
+          <div className="space-y-2">
+            <p>
+              {fields.fields.length} fields loaded from {fields.source} (sample
+              {" "}
+              {fields.sample_size})
+            </p>
+            <p>
+              EDUC API base: <code>{fields.api_base || "n/a"}</code>
+            </p>
+            {fields.note && (
+              <div className="mt-2 rounded border border-red-200 bg-red-100 p-2 text-sm text-red-800">
+                {fields.note}
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
 }
 


### PR DESCRIPTION
## Summary
- add useApi hook for generic API fetching
- implement Settings screen showing API health and field discovery details
- expose API base via env-aware helper

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6f4fe419c832eb504d5e0f63ec093