### PR TITLE
feat(web): implement wizard steps 1–3 (fields, scope, transcripts)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { NavLink, Route, Routes } from "react-router-dom";
 import Home from "./pages/Home";
-import DatasetWizard from "./pages/DatasetWizard";
+import Wizard from "./pages/Wizard";
 import Clustering from "./pages/Clustering";
 import Library from "./pages/Library";
 import Settings from "./pages/Settings";
@@ -43,7 +43,7 @@ export default function App() {
       <main className="flex-1 p-4">
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="/wizard" element={<DatasetWizard />} />
+          <Route path="/wizard" element={<Wizard />} />
           <Route path="/clustering" element={<Clustering />} />
           <Route path="/library" element={<Library />} />
           <Route path="/settings" element={<Settings />} />

--- a/web/src/pages/DatasetWizard.tsx
+++ b/web/src/pages/DatasetWizard.tsx
@@ -1,4 +1,0 @@
-export default function DatasetWizard() {
-  return <h1 className="text-xl font-bold">Dataset Wizard</h1>;
-}
-

--- a/web/src/pages/Wizard/StepFields.tsx
+++ b/web/src/pages/Wizard/StepFields.tsx
@@ -1,0 +1,69 @@
+import { Dispatch, SetStateAction } from "react";
+import { useApi } from "../../lib/useApi";
+
+type FieldsResponse = { fields: string[] };
+
+type Props = {
+  primaryKey: string;
+  setPrimaryKey: Dispatch<SetStateAction<string>>;
+  embedFields: string[];
+  setEmbedFields: Dispatch<SetStateAction<string[]>>;
+};
+
+export default function StepFields({
+  primaryKey,
+  setPrimaryKey,
+  embedFields,
+  setEmbedFields,
+}: Props) {
+  const { data, error, loading } = useApi<FieldsResponse>("/fields");
+
+  const fields = data?.fields || [];
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="font-semibold">Primary key</h2>
+        {loading && <p>Loading…</p>}
+        {error && <p className="text-red-600">{error}</p>}
+        {fields.length > 0 && (
+          <select
+            className="mt-1 w-full border p-1"
+            value={primaryKey}
+            onChange={(e) => setPrimaryKey(e.target.value)}
+          >
+            <option value="">Select…</option>
+            {fields.map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <div>
+        <h2 className="font-semibold">Embedding fields</h2>
+        {fields.length > 0 && (
+          <select
+            multiple
+            className="mt-1 w-full border p-1"
+            value={embedFields}
+            onChange={(e) =>
+              setEmbedFields(
+                Array.from(e.target.selectedOptions, (o) => o.value)
+              )
+            }
+          >
+            {fields.map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/web/src/pages/Wizard/StepScope.tsx
+++ b/web/src/pages/Wizard/StepScope.tsx
@@ -1,0 +1,109 @@
+import { Dispatch, SetStateAction, useState } from "react";
+import { API_BASE } from "../../lib/api";
+
+type UploadResponse = {
+  token: string;
+  columns: string[];
+  preview: Record<string, string>[];
+};
+
+type Props = {
+  mode: "api" | "excel";
+  setMode: Dispatch<SetStateAction<"api" | "excel">>;
+  token: string | null;
+  setToken: Dispatch<SetStateAction<string | null>>;
+  idCol: string | null;
+  setIdCol: Dispatch<SetStateAction<string | null>>;
+};
+
+export default function StepScope({
+  mode,
+  setMode,
+  token,
+  setToken,
+  idCol,
+  setIdCol,
+}: Props) {
+  const [columns, setColumns] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const form = new FormData();
+    form.append("excel", file);
+    setUploading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/upload-ids`, {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const json = (await res.json()) as UploadResponse;
+      setToken(json.token);
+      setColumns(json.columns);
+      if (json.columns.length === 1) setIdCol(json.columns[0]);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="mr-4">
+          <input
+            type="radio"
+            name="mode"
+            value="api"
+            checked={mode === "api"}
+            onChange={() => setMode("api")}
+            className="mr-1"
+          />
+          Full API
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="mode"
+            value="excel"
+            checked={mode === "excel"}
+            onChange={() => setMode("excel")}
+            className="mr-1"
+          />
+          Excel/CSV
+        </label>
+      </div>
+
+      {mode === "excel" && (
+        <div className="space-y-2">
+          <input type="file" accept=".csv,.xlsx,.xls" onChange={onFile} />
+          {uploading && <p>Uploading…</p>}
+          {error && <p className="text-red-600">{error}</p>}
+          {token && (
+            <div>
+              <label className="mr-2">ID column:</label>
+              <select
+                className="border p-1"
+                value={idCol || ""}
+                onChange={(e) => setIdCol(e.target.value)}
+              >
+                <option value="">Select…</option>
+                {columns.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/web/src/pages/Wizard/StepTranscripts.tsx
+++ b/web/src/pages/Wizard/StepTranscripts.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { API_BASE } from "../../lib/api";
+
+type PrepareResponse = {
+  primary_key: string;
+  count_included: number;
+  count_excluded: number;
+  excluded_ids: string[];
+  sample_ids: string[];
+};
+
+type Props = {
+  primaryKey: string;
+  embedFields: string[];
+  mode: "api" | "excel";
+  excelToken: string | null;
+  excelIdCol: string | null;
+};
+
+export default function StepTranscripts({
+  primaryKey,
+  embedFields,
+  mode,
+  excelToken,
+  excelIdCol,
+}: Props) {
+  const [files, setFiles] = useState<File[]>([]);
+  const [result, setResult] = useState<PrepareResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const onPrepare = async () => {
+    const form = new FormData();
+    form.append("primary_key", primaryKey);
+    embedFields.forEach((f) => form.append("embed_fields", f));
+    form.append("mode", mode);
+    if (mode === "excel" && excelToken) {
+      form.append("excel_token", excelToken);
+      if (excelIdCol) form.append("excel_id_col", excelIdCol);
+    }
+    files.forEach((f) => form.append("transcripts", f));
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/segment/prepare`, {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const json = (await res.json()) as PrepareResponse;
+      setResult(json);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <input
+          type="file"
+          accept=".docx"
+          multiple
+          onChange={(e) => setFiles(Array.from(e.target.files || []))}
+        />
+      </div>
+      <button
+        className="rounded bg-primary px-3 py-1 text-primary-foreground disabled:opacity-50"
+        disabled={files.length === 0 || loading}
+        onClick={onPrepare}
+      >
+        {loading ? "Preparing…" : "Prepare"}
+      </button>
+      {error && <p className="text-red-600">{error}</p>}
+      {result && (
+        <div className="space-y-2">
+          <p>
+            Included: {result.count_included} • Excluded: {result.count_excluded}
+          </p>
+          <div>
+            <label className="mr-2">Sample IDs:</label>
+            <select className="border p-1">
+              {result.sample_ids.map((id) => (
+                <option key={id} value={id}>
+                  {id}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/web/src/pages/Wizard/index.tsx
+++ b/web/src/pages/Wizard/index.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import StepFields from "./StepFields";
+import StepScope from "./StepScope";
+import StepTranscripts from "./StepTranscripts";
+
+const STEPS = ["Fields", "Scope", "Transcripts"];
+
+export default function Wizard() {
+  const [step, setStep] = useState(0);
+
+  const [primaryKey, setPrimaryKey] = useState("");
+  const [embedFields, setEmbedFields] = useState<string[]>([]);
+
+  const [mode, setMode] = useState<"api" | "excel">("api");
+  const [excelToken, setExcelToken] = useState<string | null>(null);
+  const [excelIdCol, setExcelIdCol] = useState<string | null>(null);
+
+  const canNext =
+    step === 0
+      ? primaryKey !== "" && embedFields.length > 0
+      : step === 1
+      ? mode === "api" || (excelToken !== null && excelIdCol !== null)
+      : false;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Dataset Wizard</h1>
+
+      <div className="flex space-x-4">
+        {STEPS.map((label, idx) => (
+          <div
+            key={label}
+            className={`rounded px-3 py-1 text-sm ${
+              idx === step ? "bg-primary text-primary-foreground" : "bg-muted"
+            }`}
+          >
+            {idx + 1}. {label}
+          </div>
+        ))}
+      </div>
+
+      {step === 0 && (
+        <StepFields
+          primaryKey={primaryKey}
+          setPrimaryKey={setPrimaryKey}
+          embedFields={embedFields}
+          setEmbedFields={setEmbedFields}
+        />
+      )}
+
+      {step === 1 && (
+        <StepScope
+          mode={mode}
+          setMode={setMode}
+          token={excelToken}
+          setToken={setExcelToken}
+          idCol={excelIdCol}
+          setIdCol={setExcelIdCol}
+        />
+      )}
+
+      {step === 2 && (
+        <StepTranscripts
+          primaryKey={primaryKey}
+          embedFields={embedFields}
+          mode={mode}
+          excelToken={excelToken}
+          excelIdCol={excelIdCol}
+        />
+      )}
+
+      <div className="flex justify-between pt-4">
+        <button
+          className="rounded border px-3 py-1"
+          disabled={step === 0}
+          onClick={() => setStep((s) => Math.max(0, s - 1))}
+        >
+          Back
+        </button>
+        {step < 2 && (
+          <button
+            className="rounded bg-primary px-3 py-1 text-primary-foreground disabled:opacity-50"
+            disabled={!canNext}
+            onClick={() => setStep((s) => s + 1)}
+          >
+            Next
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Replace placeholder wizard with stepper-based flow for dataset setup
- Step 1: choose primary key and embedding fields from `/api/fields`
- Step 2: scope dataset via full API or Excel/CSV upload to `/api/upload-ids`
- Step 3: upload transcripts and call `/api/segment/prepare` to show counts and sample IDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6f6c328ec832ea9ae67c99649550c