### PR TITLE
feat(web): add preview & async batch steps with status polling

### DIFF
--- a/web/src/pages/Wizard/Batch.tsx
+++ b/web/src/pages/Wizard/Batch.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from "react";
+import { API_BASE } from "../../lib/api";
+
+interface SegmentBatchResult {
+  uid: string;
+  count: number;
+  master_zip: string;
+  zips: string[];
+}
+
+interface JobStatus {
+  status: string;
+  note?: string;
+  result?: SegmentBatchResult;
+}
+
+interface Props {
+  primaryKey: string;
+  embedFields: string[];
+  mode: "api" | "excel";
+  excelToken: string | null;
+  excelIdCol: string | null;
+  transcripts: File[];
+  keepRatio: number;
+  setKeepRatio: (n: number) => void;
+  brief: string;
+  setBrief: (s: string) => void;
+  withTitles: boolean;
+  setWithTitles: (b: boolean) => void;
+}
+
+export default function Batch({
+  primaryKey,
+  embedFields,
+  mode,
+  excelToken,
+  excelIdCol,
+  transcripts,
+  keepRatio,
+  setKeepRatio,
+  brief,
+  setBrief,
+  withTitles,
+  setWithTitles,
+}: Props) {
+  const [job, setJob] = useState<JobStatus | null>(null);
+  const [uid, setUid] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const launch = async () => {
+    const form = new FormData();
+    form.append("primary_key", primaryKey);
+    embedFields.forEach((f) => form.append("embed_fields", f));
+    form.append("mode", mode);
+    if (mode === "excel" && excelToken) {
+      form.append("excel_token", excelToken);
+      if (excelIdCol) form.append("excel_id_col", excelIdCol);
+    }
+    transcripts.forEach((f) => form.append("transcripts", f));
+    form.append("keep_ratio", String(keepRatio));
+    if (brief) form.append("brief", brief);
+    form.append("with_titles", String(withTitles));
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/segment/batch`, {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const json = (await res.json()) as { uid: string; status: string };
+      setUid(json.uid);
+      setJob({ status: json.status });
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!uid) return;
+    const interval = setInterval(async () => {
+      const res = await fetch(`${API_BASE}/segment/status/${uid}`);
+      if (!res.ok) return;
+      const json = (await res.json()) as JobStatus;
+      setJob(json);
+      if (json.status === "done") {
+        clearInterval(interval);
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [uid]);
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div>
+          <label className="mr-2">Keep ratio:</label>
+          <input
+            type="number"
+            step="0.1"
+            value={keepRatio}
+            onChange={(e) => setKeepRatio(parseFloat(e.target.value))}
+            className="w-20 border p-1"
+          />
+        </div>
+        <div>
+          <label className="mr-2">Brief:</label>
+          <input
+            type="text"
+            value={brief}
+            onChange={(e) => setBrief(e.target.value)}
+            className="border p-1"
+          />
+        </div>
+        <div>
+          <label className="mr-2">With titles:</label>
+          <input
+            type="checkbox"
+            checked={withTitles}
+            onChange={(e) => setWithTitles(e.target.checked)}
+          />
+        </div>
+      </div>
+      <button
+        className="rounded bg-primary px-3 py-1 text-primary-foreground disabled:opacity-50"
+        disabled={loading || !!uid}
+        onClick={launch}
+      >
+        {loading ? "Launching…" : "Run batch"}
+      </button>
+      {error && <p className="text-red-600">{error}</p>}
+      {job && (
+        <p>
+          Status: {job.status}
+          {job.note ? ` – ${job.note}` : ""}
+        </p>
+      )}
+      {job?.status === "done" && job.result && (
+        <div className="space-y-2">
+          <p>Processed {job.result.count} items</p>
+          <div>
+            <a
+              className="text-blue-600 underline"
+              href={job.result.master_zip}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Download master ZIP
+            </a>
+          </div>
+          <ul className="list-disc pl-4">
+            {job.result.zips.map((z) => (
+              <li key={z}>
+                <a
+                  className="text-blue-600 underline"
+                  href={z}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {z}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Wizard/Preview.tsx
+++ b/web/src/pages/Wizard/Preview.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import DataTable from "../../components/DataTable";
+import { API_BASE } from "../../lib/api";
+
+interface ClipSegment {
+  score?: number;
+  title?: string;
+  summary?: string;
+  text?: string;
+}
+
+interface SegmentPreviewResponse {
+  pk_value: string;
+  segments: ClipSegment[];
+  n_segments: number;
+  clip_dim: number;
+  has_program_embedding: boolean;
+}
+
+interface Props {
+  primaryKey: string;
+  embedFields: string[];
+  mode: "api" | "excel";
+  excelToken: string | null;
+  excelIdCol: string | null;
+  transcripts: File[];
+  sampleIds: string[];
+  sampleId: string;
+  setSampleId: (id: string) => void;
+  keepRatio: number;
+  setKeepRatio: (n: number) => void;
+  brief: string;
+  setBrief: (s: string) => void;
+  withTitles: boolean;
+  setWithTitles: (b: boolean) => void;
+  setPreviewed: (ok: boolean) => void;
+}
+
+export default function Preview({
+  primaryKey,
+  embedFields,
+  mode,
+  excelToken,
+  excelIdCol,
+  transcripts,
+  sampleIds,
+  sampleId,
+  setSampleId,
+  keepRatio,
+  setKeepRatio,
+  brief,
+  setBrief,
+  withTitles,
+  setWithTitles,
+  setPreviewed,
+}: Props) {
+  const [result, setResult] = useState<SegmentPreviewResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onPreview = async () => {
+    const form = new FormData();
+    form.append("primary_key", primaryKey);
+    embedFields.forEach((f) => form.append("embed_fields", f));
+    form.append("mode", mode);
+    if (mode === "excel" && excelToken) {
+      form.append("excel_token", excelToken);
+      if (excelIdCol) form.append("excel_id_col", excelIdCol);
+    }
+    transcripts.forEach((f) => form.append("transcripts", f));
+    form.append("sample_pk_value", sampleId);
+    form.append("keep_ratio", String(keepRatio));
+    if (brief) form.append("brief", brief);
+    form.append("with_titles", String(withTitles));
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/segment/preview`, {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const json = (await res.json()) as SegmentPreviewResponse;
+      setResult(json);
+      setPreviewed(true);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div>
+          <label className="mr-2">Sample ID:</label>
+          <select
+            className="border p-1"
+            value={sampleId}
+            onChange={(e) => setSampleId(e.target.value)}
+          >
+            {sampleIds.map((id) => (
+              <option key={id} value={id}>
+                {id}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="mr-2">Keep ratio:</label>
+          <input
+            type="number"
+            step="0.1"
+            value={keepRatio}
+            onChange={(e) => setKeepRatio(parseFloat(e.target.value))}
+            className="w-20 border p-1"
+          />
+        </div>
+        <div>
+          <label className="mr-2">Brief:</label>
+          <input
+            type="text"
+            value={brief}
+            onChange={(e) => setBrief(e.target.value)}
+            className="border p-1"
+          />
+        </div>
+        <div>
+          <label className="mr-2">With titles:</label>
+          <input
+            type="checkbox"
+            checked={withTitles}
+            onChange={(e) => setWithTitles(e.target.checked)}
+          />
+        </div>
+      </div>
+      <button
+        className="rounded bg-primary px-3 py-1 text-primary-foreground disabled:opacity-50"
+        disabled={loading || !sampleId}
+        onClick={onPreview}
+      >
+        {loading ? "Previewing…" : "Preview"}
+      </button>
+      {error && <p className="text-red-600">{error}</p>}
+      {result && (
+        <DataTable
+          data={result.segments as Record<string, unknown>[]}
+          columns={[
+            { key: "score", label: "Score" },
+            { key: "title", label: "Title" },
+            { key: "summary", label: "Summary" },
+            { key: "text", label: "Text" },
+          ]}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Wizard/StepTranscripts.tsx
+++ b/web/src/pages/Wizard/StepTranscripts.tsx
@@ -15,6 +15,11 @@ type Props = {
   mode: "api" | "excel";
   excelToken: string | null;
   excelIdCol: string | null;
+  transcripts: File[];
+  setTranscripts: (f: File[]) => void;
+  setSampleIds: (ids: string[]) => void;
+  setSampleId: (id: string) => void;
+  setPrepared: (ok: boolean) => void;
 };
 
 export default function StepTranscripts({
@@ -23,8 +28,12 @@ export default function StepTranscripts({
   mode,
   excelToken,
   excelIdCol,
+  transcripts,
+  setTranscripts,
+  setSampleIds,
+  setSampleId,
+  setPrepared,
 }: Props) {
-  const [files, setFiles] = useState<File[]>([]);
   const [result, setResult] = useState<PrepareResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -38,9 +47,10 @@ export default function StepTranscripts({
       form.append("excel_token", excelToken);
       if (excelIdCol) form.append("excel_id_col", excelIdCol);
     }
-    files.forEach((f) => form.append("transcripts", f));
+    transcripts.forEach((f) => form.append("transcripts", f));
     setLoading(true);
     setError(null);
+    setPrepared(false);
     try {
       const res = await fetch(`${API_BASE}/segment/prepare`, {
         method: "POST",
@@ -49,6 +59,9 @@ export default function StepTranscripts({
       if (!res.ok) throw new Error(await res.text());
       const json = (await res.json()) as PrepareResponse;
       setResult(json);
+      setSampleIds(json.sample_ids);
+      setSampleId(json.sample_ids[0] || "");
+      setPrepared(true);
     } catch (err) {
       setError((err as Error).message);
     } finally {
@@ -63,12 +76,17 @@ export default function StepTranscripts({
           type="file"
           accept=".docx"
           multiple
-          onChange={(e) => setFiles(Array.from(e.target.files || []))}
+          onChange={(e) => {
+            setTranscripts(Array.from(e.target.files || []));
+            setSampleIds([]);
+            setSampleId("");
+            setPrepared(false);
+          }}
         />
       </div>
       <button
         className="rounded bg-primary px-3 py-1 text-primary-foreground disabled:opacity-50"
-        disabled={files.length === 0 || loading}
+        disabled={transcripts.length === 0 || loading}
         onClick={onPrepare}
       >
         {loading ? "Preparing…" : "Prepare"}
@@ -79,16 +97,6 @@ export default function StepTranscripts({
           <p>
             Included: {result.count_included} • Excluded: {result.count_excluded}
           </p>
-          <div>
-            <label className="mr-2">Sample IDs:</label>
-            <select className="border p-1">
-              {result.sample_ids.map((id) => (
-                <option key={id} value={id}>
-                  {id}
-                </option>
-              ))}
-            </select>
-          </div>
         </div>
       )}
     </div>

--- a/web/src/pages/Wizard/index.tsx
+++ b/web/src/pages/Wizard/index.tsx
@@ -2,8 +2,10 @@ import { useState } from "react";
 import StepFields from "./StepFields";
 import StepScope from "./StepScope";
 import StepTranscripts from "./StepTranscripts";
+import Preview from "./Preview";
+import Batch from "./Batch";
 
-const STEPS = ["Fields", "Scope", "Transcripts"];
+const STEPS = ["Fields", "Scope", "Transcripts", "Preview", "Batch"];
 
 export default function Wizard() {
   const [step, setStep] = useState(0);
@@ -15,11 +17,25 @@ export default function Wizard() {
   const [excelToken, setExcelToken] = useState<string | null>(null);
   const [excelIdCol, setExcelIdCol] = useState<string | null>(null);
 
+  const [transcripts, setTranscripts] = useState<File[]>([]);
+  const [sampleIds, setSampleIds] = useState<string[]>([]);
+  const [sampleId, setSampleId] = useState<string>("");
+  const [prepared, setPrepared] = useState(false);
+  const [previewed, setPreviewed] = useState(false);
+
+  const [keepRatio, setKeepRatio] = useState(0.6);
+  const [brief, setBrief] = useState("");
+  const [withTitles, setWithTitles] = useState(true);
+
   const canNext =
     step === 0
       ? primaryKey !== "" && embedFields.length > 0
       : step === 1
       ? mode === "api" || (excelToken !== null && excelIdCol !== null)
+      : step === 2
+      ? prepared
+      : step === 3
+      ? previewed
       : false;
 
   return (
@@ -66,6 +82,49 @@ export default function Wizard() {
           mode={mode}
           excelToken={excelToken}
           excelIdCol={excelIdCol}
+          transcripts={transcripts}
+          setTranscripts={setTranscripts}
+          setSampleIds={setSampleIds}
+          setSampleId={setSampleId}
+          setPrepared={setPrepared}
+        />
+      )}
+
+      {step === 3 && (
+        <Preview
+          primaryKey={primaryKey}
+          embedFields={embedFields}
+          mode={mode}
+          excelToken={excelToken}
+          excelIdCol={excelIdCol}
+          transcripts={transcripts}
+          sampleIds={sampleIds}
+          sampleId={sampleId}
+          setSampleId={setSampleId}
+          keepRatio={keepRatio}
+          setKeepRatio={setKeepRatio}
+          brief={brief}
+          setBrief={setBrief}
+          withTitles={withTitles}
+          setWithTitles={setWithTitles}
+          setPreviewed={setPreviewed}
+        />
+      )}
+
+      {step === 4 && (
+        <Batch
+          primaryKey={primaryKey}
+          embedFields={embedFields}
+          mode={mode}
+          excelToken={excelToken}
+          excelIdCol={excelIdCol}
+          transcripts={transcripts}
+          keepRatio={keepRatio}
+          setKeepRatio={setKeepRatio}
+          brief={brief}
+          setBrief={setBrief}
+          withTitles={withTitles}
+          setWithTitles={setWithTitles}
         />
       )}
 
@@ -77,7 +136,7 @@ export default function Wizard() {
         >
           Back
         </button>
-        {step < 2 && (
+        {step < 4 && (
           <button
             className="rounded bg-primary px-3 py-1 text-primary-foreground disabled:opacity-50"
             disabled={!canNext}


### PR DESCRIPTION
## Summary
- add preview step hitting /api/segment/preview with clip table
- add batch step launching /api/segment/batch and polling job status
- wire new wizard steps and shared options

## Testing
- `pip install -r requirements.txt`
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6f8244068832ea27ba951df825f2e