### PR TITLE
feat(web): job status drawer and unified download center

### DIFF
--- a/web/src/components/DownloadLink.tsx
+++ b/web/src/components/DownloadLink.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface Props {
+  href: string;
+}
+
+export default function DownloadLink({ href }: Props) {
+  const name = href.split("/").pop() ?? href;
+  return (
+    <a
+      className="text-blue-600 underline"
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+    >
+      {name}
+    </a>
+  );
+}

--- a/web/src/components/Jobs.tsx
+++ b/web/src/components/Jobs.tsx
@@ -1,0 +1,131 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+import DownloadLink from "./DownloadLink";
+import useJobPolling from "../hooks/useJobPolling";
+
+export interface SegmentBatchResult {
+  uid: string;
+  count: number;
+  master_zip: string;
+  zips: string[];
+}
+
+export interface JobStatus {
+  status: string;
+  note?: string;
+  result?: SegmentBatchResult;
+}
+
+interface JobEntry extends JobStatus {
+  uid: string;
+}
+
+interface JobsContextValue {
+  jobs: JobEntry[];
+  addJob: (uid: string) => void;
+  updateJob: (uid: string, job: JobStatus) => void;
+  removeJob: (uid: string) => void;
+  setDownloads: (res: SegmentBatchResult) => void;
+}
+
+const JobsContext = createContext<JobsContextValue>({
+  jobs: [],
+  addJob: () => {},
+  updateJob: () => {},
+  removeJob: () => {},
+  setDownloads: () => {},
+});
+
+export function useJobs() {
+  return useContext(JobsContext);
+}
+
+export function JobsProvider({ children }: { children: ReactNode }) {
+  const [jobs, setJobs] = useState<JobEntry[]>([]);
+  const [downloads, setDownloads] = useState<SegmentBatchResult | null>(null);
+
+  const addJob = (uid: string) =>
+    setJobs((cur) => [...cur, { uid, status: "pending" }]);
+
+  const updateJob = (uid: string, job: JobStatus) =>
+    setJobs((cur) => cur.map((j) => (j.uid === uid ? { ...j, ...job } : j)));
+
+  const removeJob = (uid: string) =>
+    setJobs((cur) => cur.filter((j) => j.uid !== uid));
+
+  return (
+    <JobsContext.Provider
+      value={{ jobs, addJob, updateJob, removeJob, setDownloads }}
+    >
+      {children}
+      {jobs.map((j) => (
+        <JobWatcher key={j.uid} uid={j.uid} />
+      ))}
+      <JobsDrawer jobs={jobs} />
+      {downloads && <DownloadsPanel result={downloads} />}
+    </JobsContext.Provider>
+  );
+}
+
+function JobsDrawer({ jobs }: { jobs: JobEntry[] }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="fixed bottom-4 left-4 space-y-2 text-sm">
+      <button
+        className="rounded bg-primary px-3 py-1 text-primary-foreground"
+        onClick={() => setOpen((o) => !o)}
+      >
+        Jobs ({jobs.length})
+      </button>
+      {open && jobs.length > 0 && (
+        <div className="rounded border bg-background p-2 shadow">
+          <ul className="space-y-1">
+            {jobs.map((j) => (
+              <li key={j.uid}>
+                {j.status}
+                {j.note ? ` – ${j.note}` : ""}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function JobWatcher({ uid }: { uid: string }) {
+  useJobPolling(uid);
+  return null;
+}
+
+function DownloadsPanel({ result }: { result: SegmentBatchResult }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="fixed bottom-4 right-4 space-y-2 text-sm">
+      <button
+        className="rounded bg-primary px-3 py-1 text-primary-foreground"
+        onClick={() => setOpen((o) => !o)}
+      >
+        Downloads
+      </button>
+      {open && (
+        <div className="max-h-60 w-64 overflow-auto rounded border bg-background p-2 shadow">
+          <div>
+            <DownloadLink href={result.master_zip} />
+          </div>
+          <ul className="list-disc pl-4">
+            {result.zips.map((z) => (
+              <li key={z}>
+                <DownloadLink href={z} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/useJobPolling.ts
+++ b/web/src/hooks/useJobPolling.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { API_BASE } from "../lib/api";
+import { useJobs, type JobStatus } from "../components/Jobs";
+
+export default function useJobPolling(uid: string | null) {
+  const { updateJob, removeJob, setDownloads } = useJobs();
+
+  useEffect(() => {
+    if (!uid) return;
+    const interval = setInterval(async () => {
+      const res = await fetch(`${API_BASE}/segment/status/${uid}`);
+      if (!res.ok) return;
+      const json = (await res.json()) as JobStatus;
+      updateJob(uid, json);
+      if (json.status === "done") {
+        clearInterval(interval);
+        removeJob(uid);
+        if (json.result) setDownloads(json.result);
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [uid, updateJob, removeJob, setDownloads]);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,12 +4,15 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
 import { ToastProvider } from "./components/Toasts";
+import { JobsProvider } from "./components/Jobs";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <ToastProvider>
-        <App />
+        <JobsProvider>
+          <App />
+        </JobsProvider>
       </ToastProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -3,6 +3,7 @@ import { api } from "../lib/api";
 import { Input } from "../components/ui/input";
 import { Button } from "../components/ui/button";
 import { useToast } from "../components/Toasts";
+import DownloadLink from "../components/DownloadLink";
 
 interface Project {
   id: number;
@@ -172,12 +173,7 @@ export default function Library() {
                   {detail.program.pk_value} ({detail.program.num_clips} clips)
                 </h2>
                 {detail.program.last_zip_path && (
-                  <a
-                    href={detail.program.last_zip_path}
-                    className="text-sm text-blue-600 underline"
-                  >
-                    Download ZIP
-                  </a>
+                  <DownloadLink href={detail.program.last_zip_path} />
                 )}
               </div>
 

--- a/web/src/pages/Wizard/Batch.tsx
+++ b/web/src/pages/Wizard/Batch.tsx
@@ -1,18 +1,6 @@
 import { useEffect, useState } from "react";
 import { API_BASE } from "../../lib/api";
-
-interface SegmentBatchResult {
-  uid: string;
-  count: number;
-  master_zip: string;
-  zips: string[];
-}
-
-interface JobStatus {
-  status: string;
-  note?: string;
-  result?: SegmentBatchResult;
-}
+import { useJobs } from "../../components/Jobs";
 
 interface Props {
   primaryKey: string;
@@ -43,10 +31,16 @@ export default function Batch({
   withTitles,
   setWithTitles,
 }: Props) {
-  const [job, setJob] = useState<JobStatus | null>(null);
   const [uid, setUid] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const { addJob, jobs } = useJobs();
+  const job = jobs.find((j) => j.uid === uid) || null;
+  const [completed, setCompleted] = useState(false);
+
+  useEffect(() => {
+    if (uid && !job) setCompleted(true);
+  }, [uid, job]);
 
   const launch = async () => {
     const form = new FormData();
@@ -71,27 +65,13 @@ export default function Batch({
       if (!res.ok) throw new Error(await res.text());
       const json = (await res.json()) as { uid: string; status: string };
       setUid(json.uid);
-      setJob({ status: json.status });
+      addJob(json.uid);
     } catch (err) {
       setError((err as Error).message);
     } finally {
       setLoading(false);
     }
   };
-
-  useEffect(() => {
-    if (!uid) return;
-    const interval = setInterval(async () => {
-      const res = await fetch(`${API_BASE}/segment/status/${uid}`);
-      if (!res.ok) return;
-      const json = (await res.json()) as JobStatus;
-      setJob(json);
-      if (json.status === "done") {
-        clearInterval(interval);
-      }
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [uid]);
 
   return (
     <div className="space-y-4">
@@ -138,35 +118,7 @@ export default function Batch({
           {job.note ? ` – ${job.note}` : ""}
         </p>
       )}
-      {job?.status === "done" && job.result && (
-        <div className="space-y-2">
-          <p>Processed {job.result.count} items</p>
-          <div>
-            <a
-              className="text-blue-600 underline"
-              href={job.result.master_zip}
-              target="_blank"
-              rel="noreferrer"
-            >
-              Download master ZIP
-            </a>
-          </div>
-          <ul className="list-disc pl-4">
-            {job.result.zips.map((z) => (
-              <li key={z}>
-                <a
-                  className="text-blue-600 underline"
-                  href={z}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {z}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      {completed && <p>Batch completed. See Downloads panel.</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add global jobs provider with drawer and downloads panel
- centralize download links and job polling utilities
- wire batch and library pages to new jobs + downloads system

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b700ff7fc0832e95790541d6895a74