### PR TITLE
fix(api): make segment status response robust across states

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,18 @@ Open http://localhost:5000 and use the UI.
 ## Notes
 - Parquet requires `pyarrow` (already in requirements).
 - For large datasets, embedding is batched with retry/backoff.
+
+## Status API contract
+
+The `/api/segment/status/{uid}` endpoint reports long-running batch jobs.
+It returns one of four states:
+
+```json
+{"status": "running", "progress": 3, "total": 10}
+{"status": "done", "result": {"uid": "abcd", "count": 10, "master_zip": "/api/download/zips/abcd.zip", "zips": [{"programme_id": "p1", "path": "/api/download/zips/abcd/p1.zip"}]}}
+{"status": "error", "message": "something went wrong"}
+{"status": "not_found", "message": "No job with this uid"}
+```
+
+Clients should handle each state accordingly and avoid assuming `result` exists
+unless `status` is `"done"`.

--- a/app/main.py
+++ b/app/main.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from .config import BASE_DIR
@@ -46,6 +47,14 @@ async def log_errors(request: Request, call_next):
     except Exception:
         logger.exception("Unhandled error for %s %s", request.method, request.url)
         raise
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"status": "error", "message": exc.detail},
+    )
 
 
 app.include_router(common_router, prefix="/api", tags=["common"])

--- a/app/routers/clip.py
+++ b/app/routers/clip.py
@@ -16,11 +16,12 @@ from ..db import engine
 from ..models import Artifact, Clip, Program, Project, Run
 from ..schemas import (
     BatchLaunchResponse,
+    BatchResult,
     ErrorResponse,
-    JobStatusResponse,
     NamedSegmentsResponse,
     SegmentPrepareResponse,
     SegmentPreviewResponse,
+    StatusResponse,
 )
 from ..services.api_client import fetch_all_programs
 from ..services.clipmaker import (
@@ -286,7 +287,6 @@ async def batch_zip(
         df = df.head(limit)
 
     uid = new_job()
-    set_status(uid, "queued")
     # 🔑 Launch in a real background thread (pass transcript names too + project info)
     _start_batch_thread(
         uid,
@@ -304,7 +304,7 @@ async def batch_zip(
         project_name,
     )
     # respond immediately; front-end will poll /segment/status/{uid}
-    return {"uid": uid, "status": "queued"}
+    return {"uid": uid, "status": "running"}
 
 
 async def _run_batch_async(
@@ -324,7 +324,7 @@ async def _run_batch_async(
 ):
     try:
         total = len(df)
-        set_status(uid, "running", f"starting… 0/{total}")
+        set_status(uid, "running", progress=0, total=total)
         out_dir = DATA_DIR / "zips" / uid
         out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -355,7 +355,7 @@ async def _run_batch_async(
             pk_value = str(row[pk_col])
             tx = t_map.get(pk_value, "").strip()
             if not tx:
-                set_status(uid, "running", f"skip (no transcript) {i}/{total}")
+                set_status(uid, "running", progress=i, total=total)
                 await asyncio.sleep(0)
                 continue
             segs = await segment_text(
@@ -407,7 +407,7 @@ async def _run_batch_async(
                         )
                     )
                 ses.commit()
-            set_status(uid, "running", f"processed {i}/{total}")
+            set_status(uid, "running", progress=i, total=total)
             await asyncio.sleep(0)  # tiny yield back to loop
 
         master_path = DATA_DIR / "zips" / f"{uid}.zip"
@@ -440,13 +440,19 @@ async def _run_batch_async(
             uid,
             {
                 "uid": uid,
-                "count": len(zip_paths),
+                "count": len(manifest),
                 "master_zip": f"/api/download/zips/{master_path.name}",
-                "zips": [f"/api/download/zips/{uid}/{Path(p).name}" for p in zip_paths],
+                "zips": [
+                    {
+                        "programme_id": m["pk"],
+                        "path": f"/api/download/zips/{uid}/{m['zip']}",
+                    }
+                    for m in manifest
+                ],
             },
         )
     except Exception as e:
-        set_status(uid, "error", str(e))
+        set_status(uid, "error", message=str(e))
 
 
 def _start_batch_thread(
@@ -489,7 +495,26 @@ def _start_batch_thread(
 
 
 @router.get(
-    "/segment/status/{uid}", response_model=JobStatusResponse, responses=ERROR_RESPONSES
+    "/segment/status/{uid}",
+    response_model=StatusResponse,
+    response_model_exclude_none=True,
+    responses=ERROR_RESPONSES,
 )
 async def batch_status(uid: str):
-    return get_job(uid)
+    job = get_job(uid)
+    if not job:
+        return StatusResponse(status="not_found", message="No job with this uid")
+    state = job.get("state")
+    if state == "running":
+        return StatusResponse(
+            status="running",
+            progress=job.get("progress"),
+            total=job.get("total"),
+        )
+    if state == "error":
+        return StatusResponse(status="error", message=job.get("message"))
+    if state == "done":
+        return StatusResponse(
+            status="done", result=BatchResult(**job.get("result", {}))
+        )
+    return StatusResponse(status="not_found", message="No job with this uid")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel
 
@@ -49,17 +49,24 @@ class BatchLaunchResponse(BaseModel):
     status: str
 
 
-class SegmentBatchResult(BaseModel):
+class ZipInfo(BaseModel):
+    programme_id: str
+    path: str
+
+
+class BatchResult(BaseModel):
     uid: str
     count: int
     master_zip: str
-    zips: List[str]
+    zips: List[ZipInfo]
 
 
-class JobStatusResponse(BaseModel):
-    status: str
-    note: Optional[str] = None
-    result: Optional[SegmentBatchResult] = None
+class StatusResponse(BaseModel):
+    status: Literal["running", "done", "error", "not_found"]
+    message: Optional[str] = None
+    progress: Optional[int] = None
+    total: Optional[int] = None
+    result: Optional[BatchResult] = None
 
 
 class ClusterMeta(BaseModel):

--- a/app/services/jobs.py
+++ b/app/services/jobs.py
@@ -1,18 +1,42 @@
-import asyncio, uuid
-from pathlib import Path
+import uuid
 
-_jobs: dict[str, dict] = {}  # {uid: {"status": "pending|running|done|error", "note": str, "result": dict}}
+JOBS: dict[str, dict] = {}
 
-def new_job():
+
+def new_job() -> str:
+    """Create a new job entry with a running state."""
+
     uid = uuid.uuid4().hex[:8]
-    _jobs[uid] = {"status": "pending", "note": "", "result": {}}
+    JOBS[uid] = {"state": "running", "progress": 0, "total": 0}
     return uid
 
-def set_status(uid, status, note=""):
-    if uid in _jobs: _jobs[uid].update({"status": status, "note": note})
 
-def set_result(uid, payload):
-    if uid in _jobs: _jobs[uid].update({"status": "done", "result": payload})
+def set_status(
+    uid: str,
+    state: str,
+    *,
+    progress: int | None = None,
+    total: int | None = None,
+    message: str | None = None,
+) -> None:
+    """Update job state, overwriting previous values."""
 
-def get_job(uid):
-    return _jobs.get(uid, {"status": "unknown", "note": "no such job"})
+    if uid not in JOBS:
+        return
+    data: dict[str, object] = {"state": state}
+    if progress is not None:
+        data["progress"] = progress
+    if total is not None:
+        data["total"] = total
+    if message is not None:
+        data["message"] = message
+    JOBS[uid] = data
+
+
+def set_result(uid: str, payload: dict) -> None:
+    if uid in JOBS:
+        JOBS[uid] = {"state": "done", "result": payload}
+
+
+def get_job(uid: str) -> dict | None:
+    return JOBS.get(uid)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,67 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.clip import router as clip_router
+from app.services import jobs
+
+
+@pytest.fixture()
+def client():
+    app = FastAPI()
+    app.include_router(clip_router)
+    return TestClient(app)
+
+
+def setup_function():
+    jobs.JOBS.clear()
+
+
+def test_status_not_found(client):
+    res = client.get("/segment/status/unknown")
+    assert res.status_code == 200
+    assert res.json()["status"] == "not_found"
+    assert "result" not in res.json()
+
+
+def test_status_running(client):
+    jobs.JOBS["abc"] = {"state": "running", "progress": 2, "total": 10}
+    res = client.get("/segment/status/abc")
+    data = res.json()
+    assert res.status_code == 200
+    assert data == {
+        "status": "running",
+        "progress": 2,
+        "total": 10,
+    }
+
+
+def test_status_error(client):
+    jobs.JOBS["abc"] = {"state": "error", "message": "boom"}
+    res = client.get("/segment/status/abc")
+    data = res.json()
+    assert res.status_code == 200
+    assert data == {"status": "error", "message": "boom"}
+
+
+def test_status_done(client):
+    jobs.JOBS["abc"] = {
+        "state": "done",
+        "result": {
+            "uid": "abc",
+            "count": 1,
+            "master_zip": "/api/download/zips/abc.zip",
+            "zips": [
+                {
+                    "programme_id": "p1",
+                    "path": "/api/download/zips/abc/p1.zip",
+                }
+            ],
+        },
+    }
+    res = client.get("/segment/status/abc")
+    data = res.json()
+    assert res.status_code == 200
+    assert data["status"] == "done"
+    assert data["result"]["uid"] == "abc"
+    assert data["result"]["count"] == 1

--- a/web/src/components/Jobs.tsx
+++ b/web/src/components/Jobs.tsx
@@ -7,18 +7,19 @@ import {
 import DownloadLink from "./DownloadLink";
 import useJobPolling from "../hooks/useJobPolling";
 
-export interface SegmentBatchResult {
+export type ZipInfo = { programme_id: string; path: string };
+export type BatchResult = {
   uid: string;
   count: number;
   master_zip: string;
-  zips: string[];
-}
+  zips: ZipInfo[];
+};
 
-export interface JobStatus {
-  status: string;
-  note?: string;
-  result?: SegmentBatchResult;
-}
+export type JobStatus =
+  | { status: "running"; progress?: number; total?: number; message?: string }
+  | { status: "error"; message: string }
+  | { status: "not_found"; message: string }
+  | { status: "done"; result: BatchResult };
 
 interface JobEntry extends JobStatus {
   uid: string;
@@ -29,7 +30,7 @@ interface JobsContextValue {
   addJob: (uid: string) => void;
   updateJob: (uid: string, job: JobStatus) => void;
   removeJob: (uid: string) => void;
-  setDownloads: (res: SegmentBatchResult) => void;
+  setDownloads: (res: BatchResult) => void;
 }
 
 const JobsContext = createContext<JobsContextValue>({
@@ -46,10 +47,10 @@ export function useJobs() {
 
 export function JobsProvider({ children }: { children: ReactNode }) {
   const [jobs, setJobs] = useState<JobEntry[]>([]);
-  const [downloads, setDownloads] = useState<SegmentBatchResult | null>(null);
+  const [downloads, setDownloads] = useState<BatchResult | null>(null);
 
   const addJob = (uid: string) =>
-    setJobs((cur) => [...cur, { uid, status: "pending" }]);
+    setJobs((cur) => [...cur, { uid, status: "running" }]);
 
   const updateJob = (uid: string, job: JobStatus) =>
     setJobs((cur) => cur.map((j) => (j.uid === uid ? { ...j, ...job } : j)));
@@ -87,7 +88,11 @@ function JobsDrawer({ jobs }: { jobs: JobEntry[] }) {
             {jobs.map((j) => (
               <li key={j.uid}>
                 {j.status}
-                {j.note ? ` – ${j.note}` : ""}
+                {j.status === "running" && j.progress !== undefined
+                  ? ` – ${j.progress}/${j.total}`
+                  : j.message
+                  ? ` – ${j.message}`
+                  : ""}
               </li>
             ))}
           </ul>
@@ -102,7 +107,7 @@ function JobWatcher({ uid }: { uid: string }) {
   return null;
 }
 
-function DownloadsPanel({ result }: { result: SegmentBatchResult }) {
+function DownloadsPanel({ result }: { result: BatchResult }) {
   const [open, setOpen] = useState(false);
   return (
     <div className="fixed bottom-4 right-4 space-y-2 text-sm">
@@ -119,8 +124,8 @@ function DownloadsPanel({ result }: { result: SegmentBatchResult }) {
           </div>
           <ul className="list-disc pl-4">
             {result.zips.map((z) => (
-              <li key={z}>
-                <DownloadLink href={z} />
+              <li key={z.path}>
+                <DownloadLink href={z.path} />
               </li>
             ))}
           </ul>

--- a/web/src/hooks/useJobPolling.ts
+++ b/web/src/hooks/useJobPolling.ts
@@ -7,17 +7,32 @@ export default function useJobPolling(uid: string | null) {
 
   useEffect(() => {
     if (!uid) return;
-    const interval = setInterval(async () => {
-      const res = await fetch(`${API_BASE}/segment/status/${uid}`);
-      if (!res.ok) return;
-      const json = (await res.json()) as JobStatus;
-      updateJob(uid, json);
-      if (json.status === "done") {
-        clearInterval(interval);
-        removeJob(uid);
-        if (json.result) setDownloads(json.result);
+    let delay = 1000;
+    let timer: ReturnType<typeof setTimeout>;
+    const poll = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/segment/status/${uid}`);
+        if (!res.ok) {
+          updateJob(uid, {
+            status: "error",
+            message: `HTTP ${res.status}`,
+          });
+          return;
+        }
+        const json = (await res.json()) as JobStatus;
+        updateJob(uid, json);
+        if (json.status === "running") {
+          delay = Math.min(delay * 1.5, 10000);
+          timer = setTimeout(poll, delay);
+        } else if (json.status === "done") {
+          removeJob(uid);
+          setDownloads(json.result);
+        }
+      } catch (e) {
+        updateJob(uid, { status: "error", message: String(e) });
       }
-    }, 1000);
-    return () => clearInterval(interval);
+    };
+    poll();
+    return () => clearTimeout(timer);
   }, [uid, updateJob, removeJob, setDownloads]);
 }


### PR DESCRIPTION
## Summary
- ensure segment status endpoint returns validated schema across running, done, error and not_found
- surface predictable errors with HTTPException handler
- handle new status shapes on the front-end and stop polling on completion or failure

## Testing
- `pre-commit run --files app/services/jobs.py app/schemas.py app/routers/clip.py app/main.py tests/test_status.py web/src/components/Jobs.tsx web/src/hooks/useJobPolling.ts README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b80788ab94832eb924b14a98a863eb