### PR TITLE
fix(web): use discriminated union for JobEntry and narrow by status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /web
 COPY web/package.json web/package-lock.json ./
 RUN npm ci
 COPY web/ .
-RUN npm run build
+RUN npm run typecheck && npm run build
 
 FROM python:3.11-slim AS builder
 

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/api/jobs.ts
+++ b/web/src/api/jobs.ts
@@ -1,0 +1,7 @@
+import type { StatusResponse } from "@/types/jobs";
+
+export async function fetchJobStatus(uid: string): Promise<StatusResponse> {
+  const res = await fetch(`/api/segment/status/${uid}`);
+  if (!res.ok) throw new Error(`Status ${res.status}`);
+  return res.json() as Promise<StatusResponse>;
+}

--- a/web/src/components/Jobs.tsx
+++ b/web/src/components/Jobs.tsx
@@ -6,29 +6,12 @@ import {
 } from "react";
 import DownloadLink from "./DownloadLink";
 import useJobPolling from "../hooks/useJobPolling";
-
-export type ZipInfo = { programme_id: string; path: string };
-export type BatchResult = {
-  uid: string;
-  count: number;
-  master_zip: string;
-  zips: ZipInfo[];
-};
-
-export type JobStatus =
-  | { status: "running"; progress?: number; total?: number; message?: string }
-  | { status: "error"; message: string }
-  | { status: "not_found"; message: string }
-  | { status: "done"; result: BatchResult };
-
-interface JobEntry extends JobStatus {
-  uid: string;
-}
+import type { BatchResult, JobEntry, StatusResponse } from "@/types/jobs";
 
 interface JobsContextValue {
   jobs: JobEntry[];
   addJob: (uid: string) => void;
-  updateJob: (uid: string, job: JobStatus) => void;
+  updateJob: (uid: string, job: StatusResponse) => void;
   removeJob: (uid: string) => void;
   setDownloads: (res: BatchResult) => void;
 }
@@ -52,8 +35,10 @@ export function JobsProvider({ children }: { children: ReactNode }) {
   const addJob = (uid: string) =>
     setJobs((cur) => [...cur, { uid, status: "running" }]);
 
-  const updateJob = (uid: string, job: JobStatus) =>
-    setJobs((cur) => cur.map((j) => (j.uid === uid ? { ...j, ...job } : j)));
+  const updateJob = (uid: string, job: StatusResponse) =>
+    setJobs((cur) =>
+      cur.map((j) => (j.uid === uid ? { ...j, ...job, updatedAt: Date.now() } : j)),
+    );
 
   const removeJob = (uid: string) =>
     setJobs((cur) => cur.filter((j) => j.uid !== uid));
@@ -88,9 +73,10 @@ function JobsDrawer({ jobs }: { jobs: JobEntry[] }) {
             {jobs.map((j) => (
               <li key={j.uid}>
                 {j.status}
-                {j.status === "running" && j.progress !== undefined
+                {j.status === "running" && "progress" in j && "total" in j &&
+                j.progress !== undefined && j.total !== undefined
                   ? ` – ${j.progress}/${j.total}`
-                  : j.message
+                  : "message" in j && j.message
                   ? ` – ${j.message}`
                   : ""}
               </li>

--- a/web/src/hooks/useJobPolling.ts
+++ b/web/src/hooks/useJobPolling.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
-import { API_BASE } from "../lib/api";
-import { useJobs, type JobStatus } from "../components/Jobs";
+import { useJobs } from "../components/Jobs";
+import { fetchJobStatus } from "../api/jobs";
+import type { StatusResponse } from "@/types/jobs";
 
 export default function useJobPolling(uid: string | null) {
   const { updateJob, removeJob, setDownloads } = useJobs();
@@ -11,15 +12,7 @@ export default function useJobPolling(uid: string | null) {
     let timer: ReturnType<typeof setTimeout>;
     const poll = async () => {
       try {
-        const res = await fetch(`${API_BASE}/segment/status/${uid}`);
-        if (!res.ok) {
-          updateJob(uid, {
-            status: "error",
-            message: `HTTP ${res.status}`,
-          });
-          return;
-        }
-        const json = (await res.json()) as JobStatus;
+        const json: StatusResponse = await fetchJobStatus(uid);
         updateJob(uid, json);
         if (json.status === "running") {
           delay = Math.min(delay * 1.5, 10000);

--- a/web/src/pages/Wizard/Batch.tsx
+++ b/web/src/pages/Wizard/Batch.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { API_BASE } from "../../lib/api";
 import { useJobs } from "../../components/Jobs";
+import type { JobEntry } from "@/types/jobs";
 
 interface Props {
   primaryKey: string;
@@ -35,7 +36,7 @@ export default function Batch({
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const { addJob, jobs } = useJobs();
-  const job = jobs.find((j) => j.uid === uid) || null;
+  const job: JobEntry | null = jobs.find((j) => j.uid === uid) || null;
   const [completed, setCompleted] = useState(false);
 
   useEffect(() => {
@@ -115,7 +116,15 @@ export default function Batch({
       {job && (
         <p>
           Status: {job.status}
-          {job.note ? ` – ${job.note}` : ""}
+          {job.status === "running" &&
+          "progress" in job &&
+          "total" in job &&
+          job.progress !== undefined &&
+          job.total !== undefined
+            ? ` – ${job.progress}/${job.total}`
+            : job.note
+            ? ` – ${job.note}`
+            : ""}
         </p>
       )}
       {completed && <p>Batch completed. See Downloads panel.</p>}

--- a/web/src/types/jobs.ts
+++ b/web/src/types/jobs.ts
@@ -1,0 +1,30 @@
+export type ZipInfo = { programme_id: string; path: string };
+export type BatchResult = {
+  uid: string;
+  count: number;
+  master_zip: string;
+  zips: ZipInfo[];
+};
+
+export type StatusRunning = {
+  status: "running";
+  progress?: number;
+  total?: number;
+  message?: string;
+};
+export type StatusError = { status: "error"; message: string };
+export type StatusNotFound = { status: "not_found"; message: string };
+export type StatusDone = { status: "done"; result: BatchResult };
+
+export type StatusResponse =
+  | StatusRunning
+  | StatusError
+  | StatusNotFound
+  | StatusDone;
+
+export type JobEntry = StatusResponse & {
+  uid: string;
+  note?: string;
+  createdAt?: number;
+  updatedAt?: number;
+};

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -14,7 +14,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { fileURLToPath, URL } from "node:url";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
   build: {
     outDir: "dist",
   },


### PR DESCRIPTION
## Summary
- define shared discriminated-union job types and typed status fetcher
- render jobs with status narrowing and progress handling
- add typecheck script and run it in Docker builds

## Testing
- `npm run typecheck`
- `npm run build`
- `docker build --target web-builder .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b80cefca90832ebc847b46ec199c63